### PR TITLE
[WHISPR-102] Configure Dependabot for multiple ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,117 @@
+version: 2
+updates:
+  # Enable version updates for Hex (Elixir packages)
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "whispr-team"
+    assignees:
+      - "whispr-team"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    # Group updates by dependency type
+    groups:
+      phoenix:
+        patterns:
+          - "phoenix*"
+        update-types:
+          - "minor"
+          - "patch"
+      ecto:
+        patterns:
+          - "ecto*"
+          - "postgrex"
+        update-types:
+          - "minor"
+          - "patch"
+      grpc:
+        patterns:
+          - "grpcbox"
+          - "protobuf"
+        update-types:
+          - "minor"
+          - "patch"
+      telemetry:
+        patterns:
+          - "telemetry*"
+          - "phoenix_live_dashboard"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-tools:
+        patterns:
+          - "credo"
+          - "dialyxir"
+          - "ex_doc"
+        update-types:
+          - "minor"
+          - "patch"
+      utilities:
+        patterns:
+          - "jason"
+          - "elixir_uuid"
+          - "gettext"
+          - "req"
+          - "swoosh"
+        update-types:
+          - "minor"
+          - "patch"
+    # Ignore specific dependencies that might cause breaking changes
+    ignore:
+      # Major version updates for core dependencies
+      - dependency-name: "phoenix"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ecto_sql"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "phoenix_ecto"
+        update-types: ["version-update:semver-major"]
+      # gRPC packages can have breaking changes in major versions
+      - dependency-name: "grpcbox"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "protobuf"
+        update-types: ["version-update:semver-major"]
+      # Ignore Elixir version requirements (these should be updated manually)
+      - dependency-name: "elixir"
+        update-types: ["version-update:semver-major"]
+    
+  # Enable version updates for Docker if you have Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "10:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "whispr-team"
+    assignees:
+      - "whispr-team"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Enable version updates for GitHub Actions if you have workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "first-tuesday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "whispr-team"
+    assignees:
+      - "whispr-team"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration to automate dependency updates for Elixir, Docker, and GitHub Actions. It sets up scheduled checks, groups dependencies for more efficient updates, and specifies rules to ignore major version bumps for critical packages to minimize breaking changes.

Dependabot configuration for automated updates:

* Added `.github/dependabot.yml` to enable automated version updates for Elixir (`mix`), Docker, and GitHub Actions dependencies with scheduled intervals and reviewer/assignee settings.
* Configured grouping of dependencies by type (e.g., Phoenix, Ecto, gRPC, telemetry, dev-tools, utilities) to streamline pull requests and reduce noise.
* Specified ignore rules to prevent major version updates for core and potentially breaking dependencies (such as `phoenix`, `ecto_sql`, `grpcbox`, and `elixir`), ensuring safer automated updates.