### PR TITLE
🐛 fix(application): add Phoenix Endpoint and PubSub to supervision tree

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,6 @@
+import Config
+
+# Do not start the HTTP server in tests — the Phoenix Endpoint is still in the
+# supervision tree (needed for PubSub routing) but should not bind a port.
+config :whispr_notification, WhisprNotificationsWeb.Endpoint,
+  server: false

--- a/docker/prod/docker-compose.prod.yml
+++ b/docker/prod/docker-compose.prod.yml
@@ -16,7 +16,7 @@ services:
       MIX_ENV: ${MIX_ENV:-prod}
 
     ports:
-      - "${HTTP_PORT:-4000}:4000"
+      - "${PORT:-4002}:4002"
       - "${GRPC_PORT:-50052}:50052"
       - "${METRICS_PORT:-9090}:9090"
 
@@ -48,7 +48,7 @@ services:
           memory: ${MEMORY_RESERVATION:-512M}
 
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:${HTTP_PORT}/api/v1/health || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:${PORT:-4002}/api/v1/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/prod/env/notification.prod.env.example
+++ b/docker/prod/env/notification.prod.env.example
@@ -1,0 +1,70 @@
+# ==============================================================================
+# Whispr Notification Service — Production Environment Variables
+# Copy this file to notification.prod.env and fill in real values.
+# ALL variables marked (required) must be set or the service will refuse to start.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Phoenix / HTTP
+# ------------------------------------------------------------------------------
+# (required) Secret used to sign sessions and LiveView tokens (mix phx.gen.secret)
+SECRET_KEY_BASE=
+
+# External hostname for URL generation (e.g. notifications.whispr.app)
+PHX_HOST=localhost
+
+# HTTP port the Phoenix endpoint binds (default: 4002)
+PORT=4002
+
+# ------------------------------------------------------------------------------
+# gRPC
+# ------------------------------------------------------------------------------
+# gRPC listen port (default: 4003)
+GRPC_PORT=4003
+
+# ------------------------------------------------------------------------------
+# Redis
+# ------------------------------------------------------------------------------
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+# Leave empty if Redis has no password
+REDIS_PASSWORD=
+
+# ------------------------------------------------------------------------------
+# Inter-service gRPC endpoints
+# ------------------------------------------------------------------------------
+AUTH_SERVICE_HOST=auth-service
+AUTH_SERVICE_PORT=50056
+
+MESSAGING_SERVICE_HOST=messaging-service
+MESSAGING_SERVICE_PORT=50052
+
+USER_SERVICE_HOST=user-service
+USER_SERVICE_PORT=50055
+
+# ------------------------------------------------------------------------------
+# Push notifications — Firebase Cloud Messaging (FCM)
+# ------------------------------------------------------------------------------
+FCM_PROJECT_ID=
+# Path to the GCP service-account JSON file inside the container
+FCM_JSON_KEYFILE=
+
+# ------------------------------------------------------------------------------
+# Push notifications — Apple Push Notification Service (APNS)
+# ------------------------------------------------------------------------------
+APNS_KEY_PATH=
+APNS_KEY_ID=
+APNS_TEAM_ID=
+# "dev" or "prod"
+APNS_MODE=prod
+
+# ------------------------------------------------------------------------------
+# Notification retention / worker tuning
+# ------------------------------------------------------------------------------
+NOTIF_RETENTION_DAYS=90
+NOTIF_CLEANUP_BATCH_SIZE=1000
+METRICS_INTERVAL_MS=60000
+CLEANUP_INTERVAL_MS=43200000
+CACHE_SYNC_INTERVAL_MS=600000
+TOKEN_REFRESH_INTERVAL_MS=3600000

--- a/lib/whispr_notifications/application.ex
+++ b/lib/whispr_notifications/application.ex
@@ -1,7 +1,7 @@
 defmodule WhisprNotifications.Application do
   @moduledoc """
   OTP application pour le domaine de notifications.
-  Démarre les superviseurs nécessaires (cache devices, workers, etc.).
+  Démarre les superviseurs nécessaires (PubSub, Endpoint HTTP, cache devices, workers, etc.).
   """
 
   use Application
@@ -9,7 +9,11 @@ defmodule WhisprNotifications.Application do
   @impl true
   def start(_type, _args) do
     children = [
-      # Exemples de superviseurs/GenServers de ton domaine
+      # PubSub — must start before the Endpoint
+      {Phoenix.PubSub, name: WhisprNotifications.PubSub},
+      # Phoenix HTTP endpoint — binds the HTTP port declared in config
+      WhisprNotificationsWeb.Endpoint,
+      # Domain supervisors/workers
       {WhisprNotifications.Devices.CacheManager, []},
       {WhisprNotifications.Workers.TokenRefresher, []},
       {WhisprNotifications.Workers.CacheSyncWorker, []},
@@ -19,5 +23,12 @@ defmodule WhisprNotifications.Application do
 
     opts = [strategy: :one_for_one, name: WhisprNotifications.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # Required by Phoenix to reload configuration on config_change/3
+  @impl true
+  def config_change(changed, _new, removed) do
+    WhisprNotificationsWeb.Endpoint.config_change(changed, removed)
+    :ok
   end
 end


### PR DESCRIPTION
## Summary
- Add Phoenix.Endpoint and Phoenix.PubSub as children in the supervision tree
- Fixes silent HTTP server startup failure in notification-service

## Test plan
- [x] Service starts correctly and HTTP endpoint responds
- [x] Health checks pass

Closes WHISPR-432