### PR TITLE
WHISPR-508: stabilize notification-service local k3d runtime

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,14 @@
 import Config
 
+# Kubernetes service env vars can be exposed either as plain ports ("3001")
+# or full URIs ("tcp://10.x.x.x:3001"). Normalize both forms.
+parse_port = fn value ->
+  case URI.parse(value) do
+    %URI{port: port} when is_integer(port) -> port
+    _ -> String.to_integer(value)
+  end
+end
+
 # ======================================================================
 # Application principale
 # ======================================================================
@@ -28,7 +37,7 @@ config :whispr_notification, WhisprNotificationsWeb.Endpoint,
 
 config :whispr_notification, :redis,
   host: System.get_env("REDIS_HOST", "localhost"),
-  port: String.to_integer(System.get_env("REDIS_PORT", "6379")),
+  port: parse_port.(System.get_env("REDIS_PORT", "6379")),
   database: String.to_integer(System.get_env("REDIS_DB", "0")),
   password: System.get_env("REDIS_PASSWORD")
 
@@ -37,7 +46,7 @@ config :whispr_notification, :redis,
 # ======================================================================
 
 config :whispr_notification,
-  grpc_port: String.to_integer(System.get_env("GRPC_PORT", "50053"))
+  grpc_port: parse_port.(System.get_env("GRPC_PORT", "50053"))
 
 # ======================================================================
 # Notifications & workers
@@ -60,15 +69,15 @@ config :whispr_notification, :workers,
 config :whispr_notification, :services,
   auth_service: %{
     host: System.get_env("AUTH_SERVICE_HOST", "auth-service"),
-    port: String.to_integer(System.get_env("AUTH_SERVICE_PORT", "50056"))
+    port: parse_port.(System.get_env("AUTH_SERVICE_PORT", "50056"))
   },
   messaging_service: %{
     host: System.get_env("MESSAGING_SERVICE_HOST", "messaging-service"),
-    port: String.to_integer(System.get_env("MESSAGING_SERVICE_PORT", "50052"))
+    port: parse_port.(System.get_env("MESSAGING_SERVICE_PORT", "50052"))
   },
   user_service: %{
     host: System.get_env("USER_SERVICE_HOST", "user-service"),
-    port: String.to_integer(System.get_env("USER_SERVICE_PORT", "50055"))
+    port: parse_port.(System.get_env("USER_SERVICE_PORT", "50055"))
   }
 
 # ======================================================================

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,8 @@
+import Config
+
+config :whispr_notification, WhisprNotificationsWeb.Endpoint,
+  http: [ip: {0, 0, 0, 0}, port: 4002],
+  check_origin: false,
+  code_reloader: false,
+  debug_errors: true,
+  secret_key_base: "development_secret_key_base_please_change_in_production"

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -13,18 +13,20 @@ RUN apt-get update && \
       git \
     && rm -rf /var/lib/apt/lists/*
 
-# Install hex and rebar with cache
-RUN --mount=type=cache,target=/root/.hex \
-    --mount=type=cache,target=/root/.mix \
-    mix local.hex --force && \
+RUN mix local.hex --force && \
     mix local.rebar --force
 
 # Copy mix files first pour le cache deps
 COPY mix.exs mix.lock ./
 
-RUN --mount=type=cache,target=/root/.hex \
-    --mount=type=cache,target=/root/.mix \
-    mix deps.get
+RUN MIX_ENV=dev mix deps.get
+
+RUN MIX_ENV=dev mix deps.compile
+
+COPY config ./config
+COPY lib ./lib
+
+RUN MIX_ENV=dev mix compile
 
 # Entrypoint dev
 COPY ./docker/dev/entrypoint.sh /tmp/entrypoint.sh

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -1,19 +1,7 @@
 #!/bin/bash
-set -e 
+set -e
 
 cd /app
 
-# Install Hex and Rebar (needed because volume mount may override them)
-mix local.hex --force
-mix local.rebar --force
-
-# Only get deps if deps directory is empty or mix.lock changed
-if [ ! -d "deps" ] || [ ! -f ".deps_installed" ] || [ "mix.lock" -nt ".deps_installed" ]; then
-    mix deps.get
-    touch .deps_installed
-fi
-
-# Run database migrations
-mix ecto.migrate
-
-mix phx.server
+MIX_ENV=dev mix ecto.migrate
+exec env MIX_ENV=dev mix phx.server


### PR DESCRIPTION
Related to WHISPR-508.

Stabilizes local k3d/Tilt runtime after end-to-end validation on 2026-03-27.