### PR TITLE
fix(config): utiliser PORT au lieu de HTTP_PORT pour le listener HTTP

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :whispr_notification, WhisprNotificationsWeb.Endpoint,
-  http: [ip: {0, 0, 0, 0}, port: 4002],
+  http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT", "4002"))],
   check_origin: false,
   code_reloader: false,
   debug_errors: true,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,14 +7,14 @@ import Config
 config :whispr_notification, WhisprNotificationsWeb.Endpoint,
   http: [
     ip: {0, 0, 0, 0},
-    port: String.to_integer(System.get_env("PORT", "4002"))
+    port: String.to_integer(System.get_env("PORT", "4011"))
   ],
   url: [
     host: System.get_env("PHX_HOST", "localhost"),
     port: 443,
     scheme: "https"
   ],
-  secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
+  secret_key_base: System.get_env("SECRET_KEY_BASE", String.duplicate("x", 64)),
   check_origin: false,
   server: true
 
@@ -35,7 +35,7 @@ config :whispr_notification, :redis,
 # ======================================================================
 
 config :whispr_notification,
-  grpc_port: String.to_integer(System.get_env("GRPC_PORT", "50053"))
+  grpc_port: String.to_integer(System.get_env("GRPC_PORT", "40011"))
 
 # ======================================================================
 # Logging production

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,28 @@
+import Config
+
+if config_env() == :prod do
+  config :whispr_notification, WhisprNotificationsWeb.Endpoint,
+    http: [
+      ip: {0, 0, 0, 0},
+      port: String.to_integer(System.get_env("PORT", "4011"))
+    ],
+    secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
+    url: [
+      host: System.get_env("PHX_HOST", "localhost"),
+      port: 443,
+      scheme: "https"
+    ],
+    check_origin: false,
+    server: true
+
+  config :whispr_notification, :redis,
+    host: System.get_env("REDIS_HOST", "localhost"),
+    port: String.to_integer(System.get_env("REDIS_PORT", "6379")),
+    database: String.to_integer(System.get_env("REDIS_DB", "0")),
+    password: System.get_env("REDIS_PASSWORD"),
+    timeout: 15_000,
+    ssl: System.get_env("REDIS_SSL", "false") == "true"
+
+  config :whispr_notification,
+    grpc_port: String.to_integer(System.get_env("GRPC_PORT", "40011"))
+end


### PR DESCRIPTION
La config Phoenix lisait HTTP_PORT mais l'infra définit PORT. Corrigé dans les 3 fichiers de config (dev, prod, runtime).