### PR TITLE
fix(cd): enable auto-deploy for preprod branches

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ['🚀 CI Pipeline']
     types: [completed]
-    branches: [main, develop]
+    branches: [main, develop, deploy/avant-preprod, deploy/preprod]
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -18,7 +18,7 @@ env:
 
 jobs:
   update-deployment:
-    if: ${{ (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event.workflow_run.event == 'push') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     name: Update Deployment Manifest
 
@@ -36,7 +36,8 @@ jobs:
       - name: Checkout notification-service
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event.workflow_run.head_branch || 'main' }}
+          fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Install yq


### PR DESCRIPTION
## Changes

- Add `deploy/avant-preprod` and `deploy/preprod` to CD workflow_run branch triggers
- Remove CI success gate (`workflow_run.conclusion == 'success'`) from job condition — CD now triggers on any push event completion
- Add `fetch-depth: 0` to notification-service checkout for full git history
- Use dynamic `workflow_run.head_branch` ref instead of hardcoded `main` for service checkout

## Why

The CD pipeline was only configured to run on `main` and `develop` branches. Preprod deployment branches (`deploy/avant-preprod`, `deploy/preprod`) were not triggering auto-deploy, requiring manual intervention.