### PR TITLE
chore(ci): reduce Discord PR notifications to merge-only [WHISPR-622]

### DIFF
--- a/.github/workflows/discord-pr-notifications.yml
+++ b/.github/workflows/discord-pr-notifications.yml
@@ -1,143 +1,45 @@
 name: 🔔 Discord PR Notifications
 
 on:
-    pull_request:
-        types: [opened, reopened, closed, ready_for_review]
-    pull_request_review:
-        types: [submitted]
+  pull_request:
+    types: [closed]
 
 permissions:
-    contents: read
-    pull-requests: read
+  contents: read
+  pull-requests: read
 
 jobs:
-    # ================================
-    # Discord PR Notifications
-    # ================================
-    notify-discord:
-        name: Send Discord Notification
-        runs-on: ubuntu-latest
-        if: github.event.pull_request.draft == false
+  notify-discord:
+    name: Send Discord Notification
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
 
-        steps:
-            - name: Determine PR action details
-              id: pr_action
-              run: |
-                  case "${{ github.event.action }}" in
-                    "opened")
-                      echo "color=3447003" >> $GITHUB_OUTPUT
-                      echo "emoji=🆕" >> $GITHUB_OUTPUT
-                      echo "text=opened" >> $GITHUB_OUTPUT
-                      ;;
-                    "reopened")
-                      echo "color=16776960" >> $GITHUB_OUTPUT
-                      echo "emoji=🔄" >> $GITHUB_OUTPUT
-                      echo "text=reopened" >> $GITHUB_OUTPUT
-                      ;;
-                    "closed")
-                      if [ "${{ github.event.pull_request.merged }}" == "true" ]; then
-                        echo "color=65280" >> $GITHUB_OUTPUT
-                        echo "emoji=✅" >> $GITHUB_OUTPUT
-                        echo "text=merged" >> $GITHUB_OUTPUT
-                      else
-                        echo "color=16711680" >> $GITHUB_OUTPUT
-                        echo "emoji=❌" >> $GITHUB_OUTPUT
-                        echo "text=closed" >> $GITHUB_OUTPUT
-                      fi
-                      ;;
-                    "ready_for_review")
-                      echo "color=3447003" >> $GITHUB_OUTPUT
-                      echo "emoji=👀" >> $GITHUB_OUTPUT
-                      echo "text=marked as ready for review" >> $GITHUB_OUTPUT
-                      ;;
-                    *)
-                      echo "color=9936031" >> $GITHUB_OUTPUT
-                      echo "emoji=📝" >> $GITHUB_OUTPUT
-                      echo "text=${{ github.event.action }}" >> $GITHUB_OUTPUT
-                      ;;
-                  esac
+    steps:
+      - name: Extract commit SHA
+        id: commit
+        run: |
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
 
-            - name: Extract commit SHA
-              id: commit
-              run: |
-                  SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
-                  echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+      - name: Send Discord notification
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: "GitHub Actions"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-title: "✅ Pull Request merged"
+          embed-description: |
+            **PR #${{ github.event.pull_request.number }}**: ${{ github.event.pull_request.title }}
 
-            - name: Send Discord notification
-              uses: tsickert/discord-webhook@v7.0.0
-              with:
-                  webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-                  username: "GitHub Actions"
-                  avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-                  embed-title: "${{ steps.pr_action.outputs.emoji }} Pull Request ${{ steps.pr_action.outputs.text }}"
-                  embed-description: |
-                      **PR #${{ github.event.pull_request.number }}**: ${{ github.event.pull_request.title }}
+            🌿 Branch: \`${{ github.event.pull_request.head.ref }}\` → \`${{ github.event.pull_request.base.ref }}\`
+            👤 Author: [${{ github.event.pull_request.user.login }}](${{ github.event.pull_request.user.html_url }})
+            📊 Changes: +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
+            📦 Commit: \`${{ steps.commit.outputs.short_sha }}\`
 
-                      🌿 Branch: \`${{ github.event.pull_request.head.ref }}\` → \`${{ github.event.pull_request.base.ref }}\`
-                      👤 Author: [${{ github.event.pull_request.user.login }}](${{ github.event.pull_request.user.html_url }})
-                      📊 Changes: +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
-                      📦 Commit: \`${{ steps.commit.outputs.short_sha }}\`
-
-                      [View Pull Request →](${{ github.event.pull_request.html_url }})
-                  embed-url: ${{ github.event.pull_request.html_url }}
-                  embed-color: ${{ steps.pr_action.outputs.color }}
-                  embed-thumbnail-url: ${{ github.event.pull_request.user.avatar_url }}
-                  embed-footer-text: "notif-service • whispr-messenger"
-                  embed-footer-icon-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-                  embed-timestamp: ${{ github.event.pull_request.created_at }}
-
-    # ================================
-    # Review notifications
-    # ================================
-    notify-review:
-        name: Send Review Notification
-        runs-on: ubuntu-latest
-        if: github.event_name == 'pull_request_review'
-
-        steps:
-            - name: Determine review details
-              id: review_action
-              run: |
-                  case "${{ github.event.review.state }}" in
-                    "approved")
-                      echo "color=65280" >> $GITHUB_OUTPUT
-                      echo "emoji=✅" >> $GITHUB_OUTPUT
-                      echo "text=approved" >> $GITHUB_OUTPUT
-                      ;;
-                    "changes_requested")
-                      echo "color=16711680" >> $GITHUB_OUTPUT
-                      echo "emoji=❌" >> $GITHUB_OUTPUT
-                      echo "text=requested changes" >> $GITHUB_OUTPUT
-                      ;;
-                    "commented")
-                      echo "color=9936031" >> $GITHUB_OUTPUT
-                      echo "emoji=💬" >> $GITHUB_OUTPUT
-                      echo "text=commented" >> $GITHUB_OUTPUT
-                      ;;
-                    *)
-                      echo "color=9936031" >> $GITHUB_OUTPUT
-                      echo "emoji=📝" >> $GITHUB_OUTPUT
-                      echo "text=${{ github.event.review.state }}" >> $GITHUB_OUTPUT
-                      ;;
-                  esac
-
-            - name: Send review notification
-              uses: tsickert/discord-webhook@v7.0.0
-              with:
-                  webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-                  username: "GitHub Actions"
-                  avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-                  embed-title: "${{ steps.review_action.outputs.emoji }} PR Review ${{ steps.review_action.outputs.text }}"
-                  embed-description: |
-                      **PR #${{ github.event.pull_request.number }}**: ${{ github.event.pull_request.title }}
-
-                      👤 Reviewer: [${{ github.event.review.user.login }}](${{ github.event.review.user.html_url }})
-                      👤 Author: [${{ github.event.pull_request.user.login }}](${{ github.event.pull_request.user.html_url }})
-
-                      [View Review →](${{ github.event.review.html_url }})
-                  embed-url: ${{ github.event.review.html_url }}
-                  embed-color: ${{ steps.review_action.outputs.color }}
-                  embed-thumbnail-url: ${{ github.event.review.user.avatar_url }}
-                  embed-footer-text: "auth-service • whispr-messenger"
-                  embed-footer-icon-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-                  embed-timestamp: ${{ github.event.review.submitted_at }}
+            [View Pull Request →](${{ github.event.pull_request.html_url }})
+          embed-url: ${{ github.event.pull_request.html_url }}
+          embed-color: 65280
+          embed-thumbnail-url: ${{ github.event.pull_request.user.avatar_url }}
+          embed-footer-text: "${{ github.event.repository.name }} • ${{ github.repository_owner }}"
+          embed-footer-icon-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-timestamp: ${{ github.event.pull_request.merged_at }}


### PR DESCRIPTION
## Summary
- Remove opened, reopened, ready_for_review PR triggers
- Remove entire pull_request_review trigger and notify-review job
- Keep only pull_request: [closed] with merged == true condition
- Simplify notification to single merge embed

Closes WHISPR-622