### PR TITLE
feat(cd): update migration-job image alongside deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -120,10 +120,15 @@ jobs:
           # Update the deployment manifest in the infrastructure repository
           yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" argocd/k8s/whispr/notification-service/deployment.yaml
 
+          # Update the migration job manifest so PreSync always uses the same image
+          yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" argocd/k8s/whispr/notification-service/migration-job.yaml
+
       - name: Verify update
         run: |
           echo "Updated deployment manifest:"
           yq '.spec.template.spec.containers[0].image' argocd/k8s/whispr/notification-service/deployment.yaml
+          echo "Updated migration job manifest:"
+          yq '.spec.template.spec.containers[0].image' argocd/k8s/whispr/notification-service/migration-job.yaml
 
       - name: Commit and push changes
         run: |
@@ -131,7 +136,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           
           # Check if there are changes to commit
-          if git diff --quiet argocd/k8s/whispr/notification-service/deployment.yaml; then
+          if git diff --quiet argocd/k8s/whispr/notification-service/deployment.yaml argocd/k8s/whispr/notification-service/migration-job.yaml; then
             echo "No changes to commit"
             exit 0
           fi
@@ -146,7 +151,7 @@ jobs:
             COMMIT_MSG="🔧 chore(deploy/notification-service): update image to ${COMMIT_SHA:0:7}"
           fi
 
-          git add argocd/k8s/whispr/notification-service/deployment.yaml
+          git add argocd/k8s/whispr/notification-service/deployment.yaml argocd/k8s/whispr/notification-service/migration-job.yaml
           git commit -m "${COMMIT_MSG}"
 
           git push https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/whispr-messenger/infrastructure.git main


### PR DESCRIPTION
## Summary
- Update cd.yml to also update `migration-job.yaml` in the infrastructure repo
- Ensures PreSync migration always uses the same image as the Deployment
- Includes both files in `git diff`, `git add`, and verify steps

## Test plan
- [x] YAML syntax valid
- [x] CI passes
- [ ] CD pipeline updates both files on main push

Closes WHISPR-647