### PR TITLE
ci: add deploy/preprod to CI trigger branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: 🚀 CI Pipeline
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
     paths-ignore:
       - 'k8s/**'
       - '**.md'
       - 'documentation/**'
       - '.github/workflows/cd.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
     paths-ignore:
       - 'k8s/**'
       - '**.md'


### PR DESCRIPTION
## Summary
- Add deploy/preprod branch to CI pipeline triggers (push + pull_request)
- Enables automatic CI when pushing to preprod branch

## Test plan
- [ ] CI triggers on push to deploy/preprod
- [ ] Existing main/develop triggers unaffected