### PR TITLE
ci: enable Docker build and deploy for deploy/preprod branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: 🚀 CI Pipeline
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
     paths-ignore:
       - 'k8s/**'
       - '**.md'
       - 'documentation/**'
       - '.github/workflows/cd.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
     paths-ignore:
       - 'k8s/**'
       - '**.md'
@@ -61,6 +61,6 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       ref: ${{ github.ref }}
-      should_deploy: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      should_deploy: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push' }}
     secrets:
       SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}


### PR DESCRIPTION
## Summary
- Add deploy/preprod to should_deploy condition in CI pipeline
- Docker images will now be built and pushed to GHCR when pushing to deploy/preprod
- No change to main branch behavior

## Test plan
- [ ] Push to main still triggers build+deploy
- [ ] Push to deploy/preprod now triggers build+deploy
- [ ] PR builds still skip deploy (event_name != push)