### PR TITLE
fix(cd): update all manifest directories on main push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,20 +54,20 @@ jobs:
             if [ -n "${{ inputs.commit_sha }}" ]; then
               COMMIT_SHA="${{ inputs.commit_sha }}"
               echo "Validating manually provided commit SHA: $COMMIT_SHA"
-              
+
               # Validate SHA format (40 hex characters for full SHA or 7+ for short SHA)
               if ! echo "$COMMIT_SHA" | grep -qE '^[a-fA-F0-9]{7,40}$'; then
                 echo "❌ Error: Invalid commit SHA format. Must be 7-40 hexadecimal characters."
                 exit 1
               fi
-              
+
               # Verify the commit exists in the repository
               if ! git rev-parse --verify "${COMMIT_SHA}^{commit}" >/dev/null 2>&1; then
                 echo "❌ Error: Commit SHA '${COMMIT_SHA}' does not exist in the repository."
                 echo "Please provide a valid commit SHA from the main branch."
                 exit 1
               fi
-              
+
               # Get the full SHA if a short SHA was provided
               COMMIT_SHA=$(git rev-parse --verify "${COMMIT_SHA}^{commit}")
               echo "✅ Commit SHA validated successfully"
@@ -89,22 +89,38 @@ jobs:
           # Store COMMIT_SHA as output for use in subsequent steps
           echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
 
+      - name: Determine trigger branch
+        id: branch_info
+        run: |
+          TRIGGER_BRANCH="${{ github.event.workflow_run.head_branch || 'main' }}"
+          echo "trigger_branch=${TRIGGER_BRANCH}" >> $GITHUB_OUTPUT
+          if [ "$TRIGGER_BRANCH" = "main" ]; then
+            echo "infra_branch=main" >> $GITHUB_OUTPUT
+          else
+            echo "infra_branch=deploy/preprod" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout infrastructure repository
         uses: actions/checkout@v4
         with:
           repository: whispr-messenger/infrastructure
-          ref: main
+          ref: ${{ steps.branch_info.outputs.infra_branch }}
           token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Pull latest infrastructure
+        run: |
+          git checkout ${{ steps.branch_info.outputs.infra_branch }}
+          git pull origin ${{ steps.branch_info.outputs.infra_branch }}
 
       - name: Update image tag in deployment
         id: update_image
         run: |
           # Use the validated commit SHA from the previous step
           COMMIT_SHA="${{ steps.validate_commit.outputs.commit_sha }}"
-          
+
           # Extract short SHA safely using printf (7 characters, matching docker metadata-action default)
           SHORT_SHA=$(printf "%.7s" "$COMMIT_SHA")
-          
+
           # Use the short SHA tag format that matches the CI docker workflow
           IMAGE_TAG="sha-${SHORT_SHA}"
 
@@ -112,38 +128,88 @@ jobs:
           FULL_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}"
           FULL_IMAGE=$(echo "${FULL_IMAGE}" | tr '[:upper:]' '[:lower:]')
 
+          TRIGGER_BRANCH="${{ steps.branch_info.outputs.trigger_branch }}"
+
           echo "Commit SHA: $COMMIT_SHA"
           echo "Short SHA: $SHORT_SHA"
           echo "Image tag: $IMAGE_TAG"
+          echo "Trigger branch: $TRIGGER_BRANCH"
           echo "Updating deployment image to: ${FULL_IMAGE}"
 
-          # Update the deployment manifest in the infrastructure repository
-          yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" argocd/k8s/whispr/notification-service/deployment.yaml
+          if [ "$TRIGGER_BRANCH" = "main" ]; then
+            # Update all three directories on main
+            echo "Updating prod, production, and preprod manifests..."
 
-          # Update the migration job manifest so PreSync always uses the same image
-          yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" argocd/k8s/whispr/notification-service/migration-job.yaml
+            yq -i 'select(.kind == "Deployment").spec.template.spec.containers[0].image = "'"${FULL_IMAGE}"'"' k8s/whispr/prod/notification-service/deployment.yaml
+            yq -i 'select(.kind == "Deployment").spec.template.spec.containers[0].image = "'"${FULL_IMAGE}"'"' k8s/whispr/production/notification-service/deployment.yaml
+            yq -i 'select(.kind == "Deployment").spec.template.spec.containers[0].image = "'"${FULL_IMAGE}"'"' k8s/whispr/preprod/notification-service/deployment.yaml
+
+            # Update migration-job in prod and preprod only (NOT production)
+            if [ -f k8s/whispr/prod/notification-service/migration-job.yaml ]; then
+              yq -i 'select(.kind == "Job").spec.template.spec.containers[0].image = "'"${FULL_IMAGE}"'"' k8s/whispr/prod/notification-service/migration-job.yaml
+            fi
+            yq -i 'select(.kind == "Job").spec.template.spec.containers[0].image = "'"${FULL_IMAGE}"'"' k8s/whispr/preprod/notification-service/migration-job.yaml
+          else
+            # Only update preprod on non-main branches
+            echo "Updating preprod manifests only..."
+
+            yq -i 'select(.kind == "Deployment").spec.template.spec.containers[0].image = "'"${FULL_IMAGE}"'"' k8s/whispr/preprod/notification-service/deployment.yaml
+            yq -i 'select(.kind == "Job").spec.template.spec.containers[0].image = "'"${FULL_IMAGE}"'"' k8s/whispr/preprod/notification-service/migration-job.yaml
+          fi
 
       - name: Verify update
         run: |
-          echo "Updated deployment manifest:"
-          yq '.spec.template.spec.containers[0].image' argocd/k8s/whispr/notification-service/deployment.yaml
-          echo "Updated migration job manifest:"
-          yq '.spec.template.spec.containers[0].image' argocd/k8s/whispr/notification-service/migration-job.yaml
+          TRIGGER_BRANCH="${{ steps.branch_info.outputs.trigger_branch }}"
+
+          if [ "$TRIGGER_BRANCH" = "main" ]; then
+            echo "=== prod deployment ==="
+            yq '.spec.template.spec.containers[0].image' k8s/whispr/prod/notification-service/deployment.yaml
+            echo "=== production deployment ==="
+            yq '.spec.template.spec.containers[0].image' k8s/whispr/production/notification-service/deployment.yaml
+            echo "=== preprod deployment ==="
+            yq '.spec.template.spec.containers[0].image' k8s/whispr/preprod/notification-service/deployment.yaml
+            echo "=== prod migration-job ==="
+            if [ -f k8s/whispr/prod/notification-service/migration-job.yaml ]; then
+              yq '.spec.template.spec.containers[0].image' k8s/whispr/prod/notification-service/migration-job.yaml
+            else
+              echo "No migration-job in prod"
+            fi
+            echo "=== preprod migration-job ==="
+            yq '.spec.template.spec.containers[0].image' k8s/whispr/preprod/notification-service/migration-job.yaml
+          else
+            echo "=== preprod deployment ==="
+            yq '.spec.template.spec.containers[0].image' k8s/whispr/preprod/notification-service/deployment.yaml
+            echo "=== preprod migration-job ==="
+            yq '.spec.template.spec.containers[0].image' k8s/whispr/preprod/notification-service/migration-job.yaml
+          fi
 
       - name: Commit and push changes
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          
+
+          TRIGGER_BRANCH="${{ steps.branch_info.outputs.trigger_branch }}"
+          INFRA_BRANCH="${{ steps.branch_info.outputs.infra_branch }}"
+
+          # Determine which files to check and add
+          if [ "$TRIGGER_BRANCH" = "main" ]; then
+            FILES_TO_ADD="k8s/whispr/prod/notification-service/deployment.yaml k8s/whispr/production/notification-service/deployment.yaml k8s/whispr/preprod/notification-service/deployment.yaml k8s/whispr/preprod/notification-service/migration-job.yaml"
+            if [ -f k8s/whispr/prod/notification-service/migration-job.yaml ]; then
+              FILES_TO_ADD="$FILES_TO_ADD k8s/whispr/prod/notification-service/migration-job.yaml"
+            fi
+          else
+            FILES_TO_ADD="k8s/whispr/preprod/notification-service/deployment.yaml k8s/whispr/preprod/notification-service/migration-job.yaml"
+          fi
+
           # Check if there are changes to commit
-          if git diff --quiet argocd/k8s/whispr/notification-service/deployment.yaml argocd/k8s/whispr/notification-service/migration-job.yaml; then
+          if git diff --quiet $FILES_TO_ADD; then
             echo "No changes to commit"
             exit 0
           fi
 
           # Use the validated commit SHA determined in the previous step
           COMMIT_SHA="${{ steps.validate_commit.outputs.commit_sha }}"
-          
+
           # Build commit message based on trigger type
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             COMMIT_MSG="🔧 chore(deploy/notification-service): update image to ${COMMIT_SHA:0:7} (manual trigger)"
@@ -151,7 +217,8 @@ jobs:
             COMMIT_MSG="🔧 chore(deploy/notification-service): update image to ${COMMIT_SHA:0:7}"
           fi
 
-          git add argocd/k8s/whispr/notification-service/deployment.yaml argocd/k8s/whispr/notification-service/migration-job.yaml
+          git add $FILES_TO_ADD
           git commit -m "${COMMIT_MSG}"
 
-          git push https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/whispr-messenger/infrastructure.git main
+          git pull origin "${INFRA_BRANCH}" --rebase
+          git push https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/whispr-messenger/infrastructure.git HEAD:"${INFRA_BRANCH}"


### PR DESCRIPTION
## Summary
- CD workflow now updates manifests in all three infrastructure directories (`prod/`, `production/`, `preprod/`) when triggered from `main`
- When triggered from `deploy/preprod`, only `preprod/` is updated (unchanged behavior)
- Migration-job is updated in `prod/` and `preprod/` but NOT in `production/` (as specified)
- Infrastructure repo checkout now uses the correct branch (`main` vs `deploy/preprod`) based on trigger branch

## Changes
- Added `branch_info` step to determine trigger branch and corresponding infra branch
- Branch-aware manifest updates with conditional logic
- Branch-aware verify and commit steps
- Fixed infrastructure checkout `ref` to use dynamic branch instead of hardcoded value
- Fixed paths from old `argocd/k8s/whispr/` to correct `k8s/whispr/` structure

## Test plan
- [ ] Push to main triggers update of prod + production + preprod deployment.yaml
- [ ] Push to main triggers update of prod + preprod migration-job.yaml (not production)
- [ ] Push to deploy/preprod triggers update of preprod only