### PR TITLE
feat(redis): migration du client Redis vers le mode Sentinel

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -20,9 +20,15 @@ config :whispr_notification, WhisprNotificationsWeb.Endpoint,
 
 # ======================================================================
 # Redis production (pour cache devices / rate limiting, etc.)
+# Sentinel par défaut — fallback host/port si REDIS_SENTINELS est vide.
 # ======================================================================
 
 config :whispr_notification, :redis,
+  sentinels:
+    System.get_env("REDIS_SENTINELS", "redis.redis.svc.cluster.local:26379")
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1),
+  group: System.get_env("REDIS_MASTER_NAME", "mymaster"),
   host: System.get_env("REDIS_HOST", "localhost"),
   port: String.to_integer(System.get_env("REDIS_PORT", "6379")),
   database: String.to_integer(System.get_env("REDIS_DB", "0")),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,6 +16,11 @@ if config_env() == :prod do
     server: true
 
   config :whispr_notification, :redis,
+    sentinels:
+      System.get_env("REDIS_SENTINELS", "redis.redis.svc.cluster.local:26379")
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1),
+    group: System.get_env("REDIS_MASTER_NAME", "mymaster"),
     host: System.get_env("REDIS_HOST", "localhost"),
     port: String.to_integer(System.get_env("REDIS_PORT", "6379")),
     database: String.to_integer(System.get_env("REDIS_DB", "0")),

--- a/docker/prod/env/notification.prod.env.example
+++ b/docker/prod/env/notification.prod.env.example
@@ -23,13 +23,21 @@ PORT=4002
 GRPC_PORT=4003
 
 # ------------------------------------------------------------------------------
-# Redis
+# Redis (Sentinel mode in production)
 # ------------------------------------------------------------------------------
-REDIS_HOST=redis
-REDIS_PORT=6379
+# Comma-separated list of "host:port" Sentinel endpoints
+REDIS_SENTINELS=redis.redis.svc.cluster.local:26379
+# Master group name announced by Sentinel
+REDIS_MASTER_NAME=mymaster
 REDIS_DB=0
 # Leave empty if Redis has no password
 REDIS_PASSWORD=
+# Enable TLS to Redis (true/false)
+REDIS_SSL=false
+
+# Legacy standalone connection — only used when REDIS_SENTINELS is empty
+REDIS_HOST=redis
+REDIS_PORT=6379
 
 # ------------------------------------------------------------------------------
 # Inter-service gRPC endpoints

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notification-service-config
+  namespace: whispr-prod
+  labels:
+    app: notification-service
+    app.kubernetes.io/name: notification-service
+    app.kubernetes.io/part-of: whispr
+data:
+  # ----------------------------------------------------------------------------
+  # Phoenix / HTTP
+  # ----------------------------------------------------------------------------
+  PORT: "4002"
+  PHX_HOST: "notifications.whispr.app"
+
+  # ----------------------------------------------------------------------------
+  # gRPC
+  # ----------------------------------------------------------------------------
+  GRPC_PORT: "4003"
+
+  # ----------------------------------------------------------------------------
+  # Redis (Sentinel mode — HA cluster in `redis` namespace)
+  # ----------------------------------------------------------------------------
+  REDIS_MODE: "sentinel"
+  REDIS_SENTINELS: "redis.redis.svc.cluster.local:26379"
+  REDIS_MASTER_NAME: "mymaster"
+  REDIS_DB: "0"
+  REDIS_SSL: "false"
+
+  # ----------------------------------------------------------------------------
+  # Inter-service gRPC endpoints
+  # ----------------------------------------------------------------------------
+  AUTH_SERVICE_HOST: "auth-service.whispr-prod.svc.cluster.local"
+  AUTH_SERVICE_PORT: "50056"
+  MESSAGING_SERVICE_HOST: "messaging-service.whispr-prod.svc.cluster.local"
+  MESSAGING_SERVICE_PORT: "50052"
+  USER_SERVICE_HOST: "user-service.whispr-prod.svc.cluster.local"
+  USER_SERVICE_PORT: "50055"
+
+  # ----------------------------------------------------------------------------
+  # Notification retention / worker tuning
+  # ----------------------------------------------------------------------------
+  NOTIF_RETENTION_DAYS: "90"
+  NOTIF_CLEANUP_BATCH_SIZE: "1000"
+  METRICS_INTERVAL_MS: "60000"
+  CLEANUP_INTERVAL_MS: "43200000"
+  CACHE_SYNC_INTERVAL_MS: "600000"
+  TOKEN_REFRESH_INTERVAL_MS: "3600000"
+
+  # ----------------------------------------------------------------------------
+  # APNS mode (secrets carry paths/keys/ids)
+  # ----------------------------------------------------------------------------
+  APNS_MODE: "prod"

--- a/lib/whispr_notifications/workers/moderation_subscriber.ex
+++ b/lib/whispr_notifications/workers/moderation_subscriber.ex
@@ -24,15 +24,7 @@ defmodule WhisprNotifications.Workers.ModerationSubscriber do
 
   @impl true
   def init(_opts) do
-    redis_config = Application.get_env(:whispr_notification, :redis, [])
-
-    redis_opts =
-      [
-        host: Keyword.get(redis_config, :host, "localhost"),
-        port: Keyword.get(redis_config, :port, 6379),
-        database: Keyword.get(redis_config, :database, 0)
-      ]
-      |> maybe_add_password(Keyword.get(redis_config, :password))
+    redis_opts = build_redix_opts()
 
     case Redix.PubSub.start_link(redis_opts) do
       {:ok, pubsub} ->
@@ -121,4 +113,42 @@ defmodule WhisprNotifications.Workers.ModerationSubscriber do
   defp maybe_add_password(opts, nil), do: opts
   defp maybe_add_password(opts, ""), do: opts
   defp maybe_add_password(opts, password), do: Keyword.put(opts, :password, password)
+
+  # Build Redix options from runtime config. If :sentinels is configured and
+  # non-empty, connect through Redis Sentinel; otherwise fall back to a
+  # standalone host/port connection (dev/docker/local).
+  defp build_redix_opts do
+    redis_config = Application.get_env(:whispr_notification, :redis, [])
+    sentinels = Keyword.get(redis_config, :sentinels, [])
+
+    base =
+      case sentinels do
+        list when is_list(list) and list != [] ->
+          [
+            sentinel: [
+              sentinels: Enum.map(list, &parse_sentinel/1),
+              group: Keyword.get(redis_config, :group, "mymaster")
+            ]
+          ]
+
+        _ ->
+          [
+            host: Keyword.get(redis_config, :host, "localhost"),
+            port: Keyword.get(redis_config, :port, 6379)
+          ]
+      end
+
+    base
+    |> Keyword.put(:database, Keyword.get(redis_config, :database, 0))
+    |> maybe_add_password(Keyword.get(redis_config, :password))
+  end
+
+  defp parse_sentinel(entry) when is_binary(entry) do
+    case String.split(entry, ":", parts: 2) do
+      [host, port] -> [host: host, port: String.to_integer(port)]
+      [host] -> [host: host, port: 26_379]
+    end
+  end
+
+  defp parse_sentinel(entry) when is_list(entry), do: entry
 end


### PR DESCRIPTION
## Contexte

Le notification-service était configuré en mode Redis **standalone** (host/port directs dans `prod.exs`). Les autres services du cluster (messaging, user, scheduling) utilisent déjà Redis en mode **Sentinel** pour la haute disponibilité. Ce PR aligne le notification-service sur le même pattern, en se connectant au cluster Redis du namespace `redis` via Sentinel (`redis.redis.svc.cluster.local:26379`, master name `mymaster`).

## Changements

- **`config/prod.exs` / `config/runtime.exs`** — ajout des clés `sentinels` (liste parsée depuis `REDIS_SENTINELS`, séparateur `,`) et `group` (`REDIS_MASTER_NAME`, défaut `mymaster`). Les anciennes clés `host`/`port` sont conservées en fallback pour le développement local.
- **`lib/whispr_notifications/workers/moderation_subscriber.ex`** — extraction d'un helper `build_redix_opts/0` qui bascule automatiquement vers `sentinel: [sentinels: […], group: …]` lorsque `:sentinels` est renseigné, et retombe sur la connexion `host`/`port` sinon.
- **`docker/prod/env/notification.prod.env.example`** — documentation des nouvelles variables (`REDIS_SENTINELS`, `REDIS_MASTER_NAME`, `REDIS_SSL`).
- **`k8s/base/configmap.yaml`** — remplissage du ConfigMap (précédemment vide) avec le bloc Sentinel aligné sur le pattern messaging-service.

## Critères d'acceptation

- [x] `prod.exs` utilise Sentinel (plus de host/port directs en prod)
- [x] Le ConfigMap K8s contient les variables Sentinel (`REDIS_MODE`, `REDIS_SENTINELS`, `REDIS_MASTER_NAME`, `REDIS_DB`)
- [ ] Les pods notification-service démarrent sans crash (à valider après déploiement)
- [ ] La connexion Redis fonctionne en production, liveness/readiness probes OK (à valider après déploiement)

## Plan de test

- [ ] `mix compile --warnings-as-errors` sans warning
- [ ] `mix format --check-formatted` propre
- [ ] `mix credo --strict` propre
- [ ] `mix test` vert
- [ ] Smoke test local avec Sentinel (ou fallback standalone en dev)

## Notes

- Le ConfigMap cible mentionné dans le ticket (`k8s/whispr/production/notification-service/configmap.yaml`) vit dans le dépôt infrastructure ; un PR séparé sera nécessaire côté infra pour appliquer les mêmes variables.
- Aucun test unitaire n'existait pour `ModerationSubscriber` — ajout d'un test Sentinel laissé hors scope de ce ticket.

Closes WHISPR-677