### PR TITLE
feat: integration tests > 90

### DIFF
--- a/lib/whispr_notifications/delivery/apns_client.ex
+++ b/lib/whispr_notifications/delivery/apns_client.ex
@@ -3,6 +3,8 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
   Client APNS pour envoyer les notifications vers iOS.
   """
 
+  require Logger
+
   alias WhisprNotifications.Devices.DeviceCache
 
   @callback send(DeviceCache.device(), map()) :: :ok | {:error, term()}
@@ -11,8 +13,24 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
 
   @impl true
   def send(device, payload) do
-    # À implémenter via Pigeon ou un service externe type MongoosePush [web:6][web:12].
-    _ = {device, payload}
+    push_fun = Application.get_env(:whispr_notification, :apns_push_fun, &default_push/2)
+
+    case push_fun.(device, payload) do
+      :ok ->
+        Logger.info("APNS push succeeded for #{device.token}")
+        :ok
+
+      {:error, reason} = err ->
+        Logger.error(
+          "APNS push failed for #{device.token}: #{inspect(reason)}"
+        )
+
+        err
+    end
+  end
+
+  defp default_push(_device, _payload) do
+    # À implémenter via Pigeon ou un service externe type MongoosePush.
     :ok
   end
 end

--- a/lib/whispr_notifications/delivery/batch_processor.ex
+++ b/lib/whispr_notifications/delivery/batch_processor.ex
@@ -3,30 +3,37 @@ defmodule WhisprNotifications.Delivery.BatchProcessor do
   Envoi batch des notifications sur un ensemble de devices.
   """
 
+  alias WhisprNotifications.Delivery.RetryManager
   alias WhisprNotifications.Devices.DeviceCache
-  alias WhisprNotifications.Notifications.{Notification, Formatter}
-  alias WhisprNotifications.Delivery.{FcmClient, ApnsClient, RetryManager}
+  alias WhisprNotifications.Notifications.{Formatter, Notification}
 
   @spec deliver(Notification.t(), DeviceCache.t()) :: :ok
   def deliver(%Notification{} = notif, %DeviceCache{devices: devices}) do
     Enum.each(devices, fn device ->
       payload = Formatter.to_platform_payload(notif, device.platform)
-      send_to_device(device.platform, device, payload, %{retries: 0, device: device, payload: payload, platform: device.platform})
+
+      send_to_device(device.platform, device, payload, %{
+        retries: 0,
+        device: device,
+        payload: payload,
+        platform: device.platform
+      })
     end)
 
     :ok
   end
 
-defp send_to_device(:android, device, payload, _attempt) do
-  FcmClient.send(device, payload)
-  :ok
-end
+  defp send_to_device(:android, device, payload, _attempt) do
+    fcm_client().send(device, payload)
+    :ok
+  end
 
-defp send_to_device(:ios, device, payload, _attempt) do
-  ApnsClient.send(device, payload)
-  :ok
-end
-
+  defp send_to_device(:ios, device, payload, attempt) do
+    case apns_client().send(device, payload) do
+      :ok -> :ok
+      {:error, _reason} -> maybe_retry(attempt)
+    end
+  end
 
   defp send_to_device(:web, _device, _payload, _attempt), do: :ok
 
@@ -37,5 +44,21 @@ end
     else
       :ok
     end
+  end
+
+  defp apns_client do
+    Application.get_env(
+      :whispr_notification,
+      :apns_client_mod,
+      WhisprNotifications.Delivery.ApnsClient
+    )
+  end
+
+  defp fcm_client do
+    Application.get_env(
+      :whispr_notification,
+      :fcm_client_mod,
+      WhisprNotifications.Delivery.FcmClient
+    )
   end
 end

--- a/lib/whispr_notifications/events/group_events.ex
+++ b/lib/whispr_notifications/events/group_events.ex
@@ -8,11 +8,11 @@ defmodule WhisprNotifications.Events.GroupEvents do
   alias WhisprNotifications.Delivery.BatchProcessor
 
   @type group_event :: %{
-    user_id: String.t(),
-    group_id: String.t(),
-    actor_id: String.t(),
-    action: :added | :removed | :role_changed
-  }
+          user_id: String.t(),
+          group_id: String.t(),
+          actor_id: String.t(),
+          action: :added | :removed | :role_changed
+        }
 
   @spec handle(group_event()) :: :ok
   def handle(event) do
@@ -22,14 +22,20 @@ defmodule WhisprNotifications.Events.GroupEvents do
         :removed -> {"Retiré de groupe", "Vous avez été retiré d'un groupe"}
         :role_changed -> {"Rôle mis à jour", "Votre rôle dans le groupe a changé"}
       end
+
     notif =
       Notification.new(%{
         user_id: event.user_id,
         type: :group,
         title: title,
         body: body,
-
+        context: %{
+          "group_id" => event.group_id,
+          "actor_id" => event.actor_id,
+          "action" => Atom.to_string(event.action)
+        }
       })
+
     if Filter.should_send?(notif) do
       {:ok, cache} = CacheManager.get_cache(event.user_id)
       :ok = BatchProcessor.deliver(notif, cache)

--- a/lib/whispr_notifications/events/message_events.ex
+++ b/lib/whispr_notifications/events/message_events.ex
@@ -9,12 +9,12 @@ defmodule WhisprNotifications.Events.MessageEvents do
   alias WhisprNotifications.Delivery.BatchProcessor
 
   @type message_event :: %{
-    user_id: String.t(),
-    conversation_id: String.t(),
-    message_id: String.t(),
-    sender_id: String.t(),
-    preview: String.t()
-  }
+          user_id: String.t(),
+          conversation_id: String.t(),
+          message_id: String.t(),
+          sender_id: String.t(),
+          preview: String.t()
+        }
 
   @spec handle_new_message(message_event()) :: :ok
   def handle_new_message(event) do
@@ -26,17 +26,17 @@ defmodule WhisprNotifications.Events.MessageEvents do
         title: "Nouveau message",
         body: event.preview,
         context: %{
-          "message_id" => event.manager_id,
+          "message_id" => event.message_id,
           "sender_id" => event.sender_id
         }
       })
 
-      if Filter.should_send?(notif) do
-        {:ok, cache} = CacheManager.get_cache(event.user_id)
-        :ok = BatchProcessor.deliver(notif, cache)
-        :ok = History.save(notif)
-      else
-        :ok
-      end
+    if Filter.should_send?(notif) do
+      {:ok, cache} = CacheManager.get_cache(event.user_id)
+      :ok = BatchProcessor.deliver(notif, cache)
+      :ok = History.save(notif)
+    else
+      :ok
+    end
   end
 end

--- a/lib/whispr_notifications/workers/moderation_subscriber.ex
+++ b/lib/whispr_notifications/workers/moderation_subscriber.ex
@@ -24,15 +24,7 @@ defmodule WhisprNotifications.Workers.ModerationSubscriber do
 
   @impl true
   def init(_opts) do
-    redis_config = Application.get_env(:whispr_notification, :redis, [])
-
-    redis_opts =
-      [
-        host: Keyword.get(redis_config, :host, "localhost"),
-        port: Keyword.get(redis_config, :port, 6379),
-        database: Keyword.get(redis_config, :database, 0)
-      ]
-      |> maybe_add_password(Keyword.get(redis_config, :password))
+    redis_opts = build_redix_opts()
 
     case Redix.PubSub.start_link(redis_opts) do
       {:ok, pubsub} ->
@@ -121,4 +113,42 @@ defmodule WhisprNotifications.Workers.ModerationSubscriber do
   defp maybe_add_password(opts, nil), do: opts
   defp maybe_add_password(opts, ""), do: opts
   defp maybe_add_password(opts, password), do: Keyword.put(opts, :password, password)
+
+  # Build Redix options from runtime config. If :sentinels is configured and
+  # non-empty, connect through Redis Sentinel; otherwise fall back to a
+  # standalone host/port connection (dev/docker/local).
+  defp build_redix_opts do
+    redis_config = Application.get_env(:whispr_notification, :redis, [])
+    sentinels = Keyword.get(redis_config, :sentinels, [])
+
+    base =
+      case sentinels do
+        list when is_list(list) and list != [] ->
+          [
+            sentinel: [
+              sentinels: Enum.map(list, &parse_sentinel/1),
+              group: Keyword.get(redis_config, :group, "mymaster")
+            ]
+          ]
+
+        _ ->
+          [
+            host: Keyword.get(redis_config, :host, "localhost"),
+            port: Keyword.get(redis_config, :port, 6379)
+          ]
+      end
+
+    base
+    |> Keyword.put(:database, Keyword.get(redis_config, :database, 0))
+    |> maybe_add_password(Keyword.get(redis_config, :password))
+  end
+
+  defp parse_sentinel(entry) when is_binary(entry) do
+    case String.split(entry, ":", parts: 2) do
+      [host, port] -> [host: host, port: String.to_integer(port)]
+      [host] -> [host: host, port: 26_379]
+    end
+  end
+
+  defp parse_sentinel(entry) when is_list(entry), do: entry
 end

--- a/test/support/notification_fixtures.ex
+++ b/test/support/notification_fixtures.ex
@@ -1,0 +1,55 @@
+defmodule WhisprNotifications.Test.NotificationFixtures do
+  @moduledoc false
+
+  alias WhisprNotifications.Devices.DeviceCache
+  alias WhisprNotifications.Notifications.Notification
+
+  @default_id "notif-test-001"
+  @default_user_id "user-test-001"
+
+  defp fake_token(prefix) do
+    prefix <> "-" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
+  end
+
+  def build_notification(overrides \\ %{}) do
+    defaults = %{
+      id: @default_id,
+      user_id: @default_user_id,
+      type: :message,
+      title: "New message",
+      body: "Hello from tests",
+      context: %{"conversation_id" => "conv-1"},
+      created_at: ~U[2026-01-01 12:00:00Z]
+    }
+
+    Notification.new(Map.merge(defaults, overrides))
+  end
+
+  def build_ios_device(overrides \\ %{}) do
+    Map.merge(
+      %{token: fake_token("test-ios"), platform: :ios, app: "com.whispr.app"},
+      overrides
+    )
+  end
+
+  def build_android_device(overrides \\ %{}) do
+    Map.merge(
+      %{token: fake_token("test-android"), platform: :android, app: nil},
+      overrides
+    )
+  end
+
+  def build_web_device(overrides \\ %{}) do
+    Map.merge(
+      %{token: fake_token("test-web"), platform: :web, app: nil},
+      overrides
+    )
+  end
+
+  def build_device_cache(overrides \\ []) do
+    user_id = Keyword.get(overrides, :user_id, @default_user_id)
+    devices = Keyword.get(overrides, :devices, [build_ios_device()])
+
+    %DeviceCache{user_id: user_id, devices: devices}
+  end
+end

--- a/test/support/spy_apns_client.ex
+++ b/test/support/spy_apns_client.ex
@@ -1,0 +1,20 @@
+defmodule WhisprNotifications.Test.SpyApnsClient do
+  @moduledoc false
+
+  @behaviour WhisprNotifications.Delivery.ApnsClient
+
+  @impl true
+  def send(device, payload) do
+    test_pid = Application.get_env(:whispr_notification, :apns_spy_pid)
+
+    if test_pid do
+      Kernel.send(test_pid, {:apns_send, device, payload})
+    end
+
+    case Application.get_env(:whispr_notification, :apns_spy_response) do
+      nil -> :ok
+      fun when is_function(fun) -> fun.()
+      value -> value
+    end
+  end
+end

--- a/test/support/spy_fcm_client.ex
+++ b/test/support/spy_fcm_client.ex
@@ -1,0 +1,16 @@
+defmodule WhisprNotifications.Test.SpyFcmClient do
+  @moduledoc false
+
+  @behaviour WhisprNotifications.Delivery.FcmClient
+
+  @impl true
+  def send(device, payload) do
+    test_pid = Application.get_env(:whispr_notification, :fcm_spy_pid)
+
+    if test_pid do
+      Kernel.send(test_pid, {:fcm_send, device, payload})
+    end
+
+    :ok
+  end
+end

--- a/test/whispr_notifications/auth/jwks_cache_extra_test.exs
+++ b/test/whispr_notifications/auth/jwks_cache_extra_test.exs
@@ -1,0 +1,99 @@
+defmodule WhisprNotifications.Auth.JwksCacheExtraTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Auth.JwksCache
+  alias WhisprNotifications.Test.ES256JwtFixtures
+
+  # Clear any :jwt config left by other tests so options-only paths are exercised.
+  setup do
+    previous = Application.get_env(:whispr_notification, :jwt)
+    Application.delete_env(:whispr_notification, :jwt)
+
+    on_exit(fn ->
+      if previous == nil do
+        Application.delete_env(:whispr_notification, :jwt)
+      else
+        Application.put_env(:whispr_notification, :jwt, previous)
+      end
+    end)
+
+    :ok
+  end
+
+  test "start_link/1 supports :inline_jwks option" do
+    inline = Jason.encode!(%{"keys" => [ES256JwtFixtures.primary_jwks_public_entry()]})
+    server = :jwks_cache_inline_test
+
+    start_supervised!({JwksCache, [name: server, inline_jwks: inline]})
+
+    assert {:ok, %JOSE.JWK{}} = JwksCache.get_key(ES256JwtFixtures.primary_kid(), server)
+  end
+
+  test "start_link/1 supports :allow_empty" do
+    server = :jwks_cache_empty_test
+
+    start_supervised!({JwksCache, [name: server, allow_empty: true]})
+
+    assert {:error, :unknown_kid} = JwksCache.get_key("anything", server)
+  end
+
+  test "handle_call({:replace_keys, map}) swaps the key set" do
+    server = :jwks_cache_replace_test
+    start_supervised!({JwksCache, [name: server, allow_empty: true]})
+
+    inline = Jason.encode!(%{"keys" => [ES256JwtFixtures.primary_jwks_public_entry()]})
+    {:ok, keys} = WhisprNotifications.Auth.Jwks.keys_from_json(inline)
+
+    assert :ok = GenServer.call(server, {:replace_keys, keys})
+    assert {:ok, %JOSE.JWK{}} = JwksCache.get_key(ES256JwtFixtures.primary_kid(), server)
+  end
+
+  test "http_get_fun returning non-200 bubbles up as {:http, status}" do
+    server = :jwks_cache_http_error_test
+    http_get_fun = fn _ -> {:ok, %{status: 503}} end
+
+    Process.flag(:trap_exit, true)
+
+    assert {:error, {:http, 503}} =
+             JwksCache.start_link(
+               name: server,
+               jwks_url: "http://x",
+               http_get_fun: http_get_fun
+             )
+  end
+
+  test "http_get_fun returning :error tuple bubbles up" do
+    server = :jwks_cache_http_err2_test
+    http_get_fun = fn _ -> {:error, :econnrefused} end
+
+    Process.flag(:trap_exit, true)
+
+    assert {:error, :econnrefused} =
+             JwksCache.start_link(
+               name: server,
+               jwks_url: "http://x",
+               http_get_fun: http_get_fun
+             )
+  end
+
+  test "http_get_fun returning unexpected shape is wrapped in :bad_http_result" do
+    server = :jwks_cache_http_weird_test
+    http_get_fun = fn _ -> :nope end
+
+    Process.flag(:trap_exit, true)
+
+    assert {:error, {:bad_http_result, :nope}} =
+             JwksCache.start_link(
+               name: server,
+               jwks_url: "http://x",
+               http_get_fun: http_get_fun
+             )
+  end
+
+  test "without any option and without jwks_url returns :bad_jwks_opts" do
+    server = :jwks_cache_no_opts_test
+    Process.flag(:trap_exit, true)
+
+    assert {:error, {:bad_jwks_opts, _}} = JwksCache.start_link(name: server)
+  end
+end

--- a/test/whispr_notifications/auth/jwks_test.exs
+++ b/test/whispr_notifications/auth/jwks_test.exs
@@ -1,0 +1,43 @@
+defmodule WhisprNotifications.Auth.JwksTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Auth.Jwks
+  alias WhisprNotifications.Test.ES256JwtFixtures
+
+  describe "keys_from_json/1" do
+    test "parses a valid JWKS and indexes by kid" do
+      json = Jason.encode!(%{"keys" => [ES256JwtFixtures.primary_jwks_public_entry()]})
+
+      assert {:ok, map} = Jwks.keys_from_json(json)
+      assert Map.has_key?(map, ES256JwtFixtures.primary_kid())
+      assert %JOSE.JWK{} = map[ES256JwtFixtures.primary_kid()]
+    end
+
+    test "returns :invalid_jwks_shape when 'keys' is missing" do
+      assert {:error, :invalid_jwks_shape} = Jwks.keys_from_json(Jason.encode!(%{}))
+    end
+
+    test "returns :invalid_json on malformed JSON" do
+      assert {:error, :invalid_json} = Jwks.keys_from_json("not-json")
+    end
+
+    test "skips keys without a kid" do
+      key = ES256JwtFixtures.primary_jwks_public_entry() |> Map.delete("kid")
+      json = Jason.encode!(%{"keys" => [key]})
+
+      assert {:ok, map} = Jwks.keys_from_json(json)
+      assert map == %{}
+    end
+
+    test "skips keys with wrong curve/kty" do
+      bad =
+        ES256JwtFixtures.primary_jwks_public_entry()
+        |> Map.put("crv", "P-384")
+
+      json = Jason.encode!(%{"keys" => [bad]})
+
+      assert {:ok, map} = Jwks.keys_from_json(json)
+      assert map == %{}
+    end
+  end
+end

--- a/test/whispr_notifications/auth/jwt_verifier_extra_test.exs
+++ b/test/whispr_notifications/auth/jwt_verifier_extra_test.exs
@@ -1,0 +1,109 @@
+defmodule WhisprNotifications.Auth.JwtVerifierExtraTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Auth.{JwksCache, JwtVerifier}
+  alias WhisprNotifications.Test.ES256JwtFixtures
+
+  setup do
+    jwks_key = ES256JwtFixtures.primary_jwks_public_entry()
+    http_get_fun = fn _url -> {:ok, %{status: 200, body: %{"keys" => [jwks_key]}}} end
+    server = :jwks_cache_jwt_verifier_extra_test
+
+    original = Application.get_env(:whispr_notification, :jwt)
+
+    Application.put_env(
+      :whispr_notification,
+      :jwt,
+      jwks_url: "http://auth-service/auth/.well-known/jwks.json",
+      issuer: "whispr-auth",
+      audience: "whispr-notification",
+      allowed_algs: ["ES256"],
+      jwks_refresh_interval_ms: 60_000,
+      jwks_cache_server: server
+    )
+
+    start_supervised!({JwksCache, [name: server, http_get_fun: http_get_fun]})
+
+    on_exit(fn ->
+      if original == nil do
+        Application.delete_env(:whispr_notification, :jwt)
+      else
+        Application.put_env(:whispr_notification, :jwt, original)
+      end
+    end)
+
+    :ok
+  end
+
+  test "rejects malformed token header" do
+    assert {:error, :invalid_header} = JwtVerifier.verify("not-a-jwt")
+  end
+
+  test "rejects expired tokens" do
+    kid = ES256JwtFixtures.primary_kid()
+
+    token =
+      sign_es256(ES256JwtFixtures.primary_private_jwk(), kid, %{
+        "sub" => "u",
+        "exp" => 1
+      })
+
+    assert {:error, :expired} = JwtVerifier.verify(token)
+  end
+
+  test "rejects wrong issuer" do
+    kid = ES256JwtFixtures.primary_kid()
+
+    token =
+      sign_es256(ES256JwtFixtures.primary_private_jwk(), kid, %{
+        "sub" => "u",
+        "iss" => "someone-else"
+      })
+
+    assert {:error, :invalid_issuer} = JwtVerifier.verify(token)
+  end
+
+  test "rejects wrong audience" do
+    kid = ES256JwtFixtures.primary_kid()
+
+    token =
+      sign_es256(ES256JwtFixtures.primary_private_jwk(), kid, %{
+        "sub" => "u",
+        "aud" => "other-service"
+      })
+
+    assert {:error, :invalid_audience} = JwtVerifier.verify(token)
+  end
+
+  test "rejects unsupported algorithms" do
+    # Build a token where header alg is not in allowed list.
+    header =
+      %{"alg" => "HS256", "kid" => ES256JwtFixtures.primary_kid()}
+      |> Jason.encode!()
+      |> Base.url_encode64(padding: false)
+
+    claims = %{"sub" => "u"} |> Jason.encode!() |> Base.url_encode64(padding: false)
+    fake_sig = Base.url_encode64("sig", padding: false)
+
+    token = Enum.join([header, claims, fake_sig], ".")
+
+    assert {:error, :unsupported_alg} = JwtVerifier.verify(token)
+  end
+
+  defp sign_es256(priv, kid, claims) do
+    now = System.system_time(:second)
+
+    claims =
+      Map.merge(
+        %{"iss" => "whispr-auth", "aud" => "whispr-notification", "exp" => now + 3600},
+        claims
+      )
+
+    {_, token} =
+      priv
+      |> JOSE.JWT.sign(%{"alg" => "ES256", "kid" => kid}, claims)
+      |> JOSE.JWS.compact()
+
+    token
+  end
+end

--- a/test/whispr_notifications/delivery/apns_client_test.exs
+++ b/test/whispr_notifications/delivery/apns_client_test.exs
@@ -1,0 +1,102 @@
+defmodule WhisprNotifications.Delivery.ApnsClientTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias WhisprNotifications.Delivery.ApnsClient
+  alias WhisprNotifications.Test.NotificationFixtures
+
+  setup do
+    original = Application.get_env(:whispr_notification, :apns_push_fun)
+
+    on_exit(fn ->
+      if original do
+        Application.put_env(:whispr_notification, :apns_push_fun, original)
+      else
+        Application.delete_env(:whispr_notification, :apns_push_fun)
+      end
+    end)
+
+    device = NotificationFixtures.build_ios_device()
+
+    payload = %{
+      "aps" => %{
+        "alert" => %{"title" => "Test", "body" => "Hello"},
+        "sound" => "default"
+      },
+      "meta" => %{"notification_id" => "n1", "type" => "message"}
+    }
+
+    {:ok, device: device, payload: payload}
+  end
+
+  describe "send/2 success" do
+    test "returns :ok when push function succeeds", %{device: device, payload: payload} do
+      Application.put_env(:whispr_notification, :apns_push_fun, fn _d, _p -> :ok end)
+
+      assert :ok == ApnsClient.send(device, payload)
+    end
+
+    test "logs success with device token", %{device: device, payload: payload} do
+      Application.put_env(:whispr_notification, :apns_push_fun, fn _d, _p -> :ok end)
+
+      log =
+        capture_log(fn ->
+          ApnsClient.send(device, payload)
+        end)
+
+      assert log =~ "APNS push succeeded"
+    end
+  end
+
+  describe "send/2 errors" do
+    test "returns {:error, :invalid_device_token}", %{device: device, payload: payload} do
+      Application.put_env(:whispr_notification, :apns_push_fun, fn _d, _p ->
+        {:error, :invalid_device_token}
+      end)
+
+      assert {:error, :invalid_device_token} == ApnsClient.send(device, payload)
+    end
+
+    test "returns {:error, :service_unavailable} on provider outage", %{
+      device: device,
+      payload: payload
+    } do
+      Application.put_env(:whispr_notification, :apns_push_fun, fn _d, _p ->
+        {:error, :service_unavailable}
+      end)
+
+      assert {:error, :service_unavailable} == ApnsClient.send(device, payload)
+    end
+
+    test "returns {:error, :timeout} on push timeout", %{device: device, payload: payload} do
+      Application.put_env(:whispr_notification, :apns_push_fun, fn _d, _p ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, :timeout} == ApnsClient.send(device, payload)
+    end
+
+    test "logs error details on failure", %{device: device, payload: payload} do
+      Application.put_env(:whispr_notification, :apns_push_fun, fn _d, _p ->
+        {:error, :invalid_device_token}
+      end)
+
+      log =
+        capture_log(fn ->
+          ApnsClient.send(device, payload)
+        end)
+
+      assert log =~ "APNS push failed"
+      assert log =~ "invalid_device_token"
+    end
+  end
+
+  describe "send/2 default behaviour" do
+    test "uses default push function when none configured", %{device: device, payload: payload} do
+      Application.delete_env(:whispr_notification, :apns_push_fun)
+
+      assert :ok == ApnsClient.send(device, payload)
+    end
+  end
+end

--- a/test/whispr_notifications/delivery/batch_processor_test.exs
+++ b/test/whispr_notifications/delivery/batch_processor_test.exs
@@ -1,0 +1,149 @@
+defmodule WhisprNotifications.Delivery.BatchProcessorTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Delivery.BatchProcessor
+  alias WhisprNotifications.Test.NotificationFixtures
+
+  setup do
+    original_apns = Application.get_env(:whispr_notification, :apns_client_mod)
+    original_fcm = Application.get_env(:whispr_notification, :fcm_client_mod)
+    original_spy_pid = Application.get_env(:whispr_notification, :apns_spy_pid)
+    original_spy_resp = Application.get_env(:whispr_notification, :apns_spy_response)
+    original_fcm_pid = Application.get_env(:whispr_notification, :fcm_spy_pid)
+
+    Application.put_env(
+      :whispr_notification,
+      :apns_client_mod,
+      WhisprNotifications.Test.SpyApnsClient
+    )
+
+    Application.put_env(
+      :whispr_notification,
+      :fcm_client_mod,
+      WhisprNotifications.Test.SpyFcmClient
+    )
+
+    Application.put_env(:whispr_notification, :apns_spy_pid, self())
+    Application.put_env(:whispr_notification, :fcm_spy_pid, self())
+    Application.delete_env(:whispr_notification, :apns_spy_response)
+
+    on_exit(fn ->
+      restore(:apns_client_mod, original_apns)
+      restore(:fcm_client_mod, original_fcm)
+      restore(:apns_spy_pid, original_spy_pid)
+      restore(:apns_spy_response, original_spy_resp)
+      restore(:fcm_spy_pid, original_fcm_pid)
+    end)
+
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:whispr_notification, key)
+  defp restore(key, val), do: Application.put_env(:whispr_notification, key, val)
+
+  describe "deliver/2 APNS routing" do
+    test "sends APNS payload to each iOS device" do
+      notif = NotificationFixtures.build_notification()
+      d1 = NotificationFixtures.build_ios_device(%{token: "tok-1"})
+      d2 = NotificationFixtures.build_ios_device(%{token: "tok-2"})
+      cache = NotificationFixtures.build_device_cache(devices: [d1, d2])
+
+      assert :ok == BatchProcessor.deliver(notif, cache)
+
+      assert_receive {:apns_send, %{token: "tok-1"}, _payload}
+      assert_receive {:apns_send, %{token: "tok-2"}, _payload}
+    end
+
+    test "formats payload as APNS before sending" do
+      notif = NotificationFixtures.build_notification(%{title: "Hey", body: "World"})
+      cache = NotificationFixtures.build_device_cache()
+
+      BatchProcessor.deliver(notif, cache)
+
+      assert_receive {:apns_send, _device, payload}
+      assert %{"aps" => %{"alert" => %{"title" => "Hey", "body" => "World"}}} = payload
+      assert payload["aps"]["sound"] == "default"
+    end
+
+    test "does not call ApnsClient for android devices" do
+      notif = NotificationFixtures.build_notification()
+      android = NotificationFixtures.build_android_device()
+      cache = NotificationFixtures.build_device_cache(devices: [android])
+
+      BatchProcessor.deliver(notif, cache)
+
+      refute_receive {:apns_send, _, _}
+      assert_receive {:fcm_send, _, _}
+    end
+
+    test "handles mixed platform device list" do
+      notif = NotificationFixtures.build_notification()
+
+      ios = NotificationFixtures.build_ios_device(%{token: "ios-tok"})
+      android = NotificationFixtures.build_android_device(%{token: "android-tok"})
+      web = NotificationFixtures.build_web_device(%{token: "web-tok"})
+      cache = NotificationFixtures.build_device_cache(devices: [ios, android, web])
+
+      BatchProcessor.deliver(notif, cache)
+
+      assert_receive {:apns_send, %{token: "ios-tok"}, _}
+      assert_receive {:fcm_send, %{token: "android-tok"}, _}
+      refute_receive {:apns_send, %{token: "android-tok"}, _}
+      refute_receive {:apns_send, %{token: "web-tok"}, _}
+    end
+
+    test "returns :ok even when sends fail" do
+      Application.put_env(
+        :whispr_notification,
+        :apns_spy_response,
+        {:error, :service_unavailable}
+      )
+
+      notif = NotificationFixtures.build_notification()
+      cache = NotificationFixtures.build_device_cache()
+
+      assert :ok == BatchProcessor.deliver(notif, cache)
+    end
+  end
+
+  describe "deliver/2 retry behaviour" do
+    test "retries on APNS failure" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Application.put_env(:whispr_notification, :apns_spy_response, fn ->
+        call = Agent.get_and_update(counter, fn n -> {n, n + 1} end)
+        if call == 0, do: {:error, :service_unavailable}, else: :ok
+      end)
+
+      notif = NotificationFixtures.build_notification()
+      cache = NotificationFixtures.build_device_cache()
+
+      BatchProcessor.deliver(notif, cache)
+
+      assert_receive {:apns_send, _, _}
+      assert_receive {:apns_send, _, _}
+
+      Agent.stop(counter)
+    end
+
+    test "stops retrying after max retries (3)" do
+      Application.put_env(
+        :whispr_notification,
+        :apns_spy_response,
+        {:error, :service_unavailable}
+      )
+
+      notif = NotificationFixtures.build_notification()
+      cache = NotificationFixtures.build_device_cache()
+
+      BatchProcessor.deliver(notif, cache)
+
+      # 1 initial + 3 retries = 4 calls
+      for _ <- 1..4 do
+        assert_receive {:apns_send, _, _}
+      end
+
+      refute_receive {:apns_send, _, _}
+    end
+  end
+end

--- a/test/whispr_notifications/delivery/fcm_client_test.exs
+++ b/test/whispr_notifications/delivery/fcm_client_test.exs
@@ -1,0 +1,12 @@
+defmodule WhisprNotifications.Delivery.FcmClientTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Delivery.FcmClient
+
+  test "send/2 returns :ok with any device/payload" do
+    device = %{token: "fcm-token", platform: :android, app: nil}
+    payload = %{notification: %{title: "t", body: "b"}, data: %{}}
+
+    assert :ok = FcmClient.send(device, payload)
+  end
+end

--- a/test/whispr_notifications/delivery/retry_manager_test.exs
+++ b/test/whispr_notifications/delivery/retry_manager_test.exs
@@ -1,0 +1,46 @@
+defmodule WhisprNotifications.Delivery.RetryManagerTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Delivery.RetryManager
+
+  @base_attempt %{
+    device: %{token: "tok", platform: :ios, app: nil},
+    payload: %{"aps" => %{}},
+    platform: :ios,
+    retries: 0
+  }
+
+  describe "should_retry?/1" do
+    test "returns true when retries is 0" do
+      assert RetryManager.should_retry?(%{@base_attempt | retries: 0})
+    end
+
+    test "returns true when retries is 2 (below max)" do
+      assert RetryManager.should_retry?(%{@base_attempt | retries: 2})
+    end
+
+    test "returns false when retries equals max (3)" do
+      refute RetryManager.should_retry?(%{@base_attempt | retries: 3})
+    end
+
+    test "returns false when retries exceeds max" do
+      refute RetryManager.should_retry?(%{@base_attempt | retries: 5})
+    end
+  end
+
+  describe "next_attempt/1" do
+    test "increments retry count by 1" do
+      attempt = %{@base_attempt | retries: 1}
+      assert RetryManager.next_attempt(attempt).retries == 2
+    end
+
+    test "preserves all other fields" do
+      attempt = @base_attempt
+      next = RetryManager.next_attempt(attempt)
+
+      assert next.device == attempt.device
+      assert next.payload == attempt.payload
+      assert next.platform == attempt.platform
+    end
+  end
+end

--- a/test/whispr_notifications/devices/auth_client_test.exs
+++ b/test/whispr_notifications/devices/auth_client_test.exs
@@ -1,0 +1,10 @@
+defmodule WhisprNotifications.Devices.AuthClientTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Devices.{AuthClient, DeviceCache}
+
+  test "fetch_devices/1 returns an empty DeviceCache for the given user" do
+    assert {:ok, %DeviceCache{user_id: "user-42", devices: []}} =
+             AuthClient.fetch_devices("user-42")
+  end
+end

--- a/test/whispr_notifications/devices/cache_manager_test.exs
+++ b/test/whispr_notifications/devices/cache_manager_test.exs
@@ -1,0 +1,28 @@
+defmodule WhisprNotifications.Devices.CacheManagerTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Devices.{CacheManager, DeviceCache}
+
+  describe "get_cache/1" do
+    test "lazily fetches a user's cache via AuthClient when absent" do
+      assert {:ok, %DeviceCache{user_id: "cm-user-1", devices: []}} =
+               CacheManager.get_cache("cm-user-1")
+    end
+
+    test "returns the same cache on subsequent calls (cached)" do
+      {:ok, first} = CacheManager.get_cache("cm-user-2")
+      {:ok, second} = CacheManager.get_cache("cm-user-2")
+
+      assert first == second
+    end
+  end
+
+  describe "refresh_cache/1" do
+    test "returns :ok and updates the state asynchronously" do
+      assert :ok = CacheManager.refresh_cache("cm-user-3")
+
+      assert {:ok, %DeviceCache{user_id: "cm-user-3"}} =
+               CacheManager.get_cache("cm-user-3")
+    end
+  end
+end

--- a/test/whispr_notifications/devices/device_cache_test.exs
+++ b/test/whispr_notifications/devices/device_cache_test.exs
@@ -1,0 +1,64 @@
+defmodule WhisprNotifications.Devices.DeviceCacheTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Devices.DeviceCache
+
+  describe "add_device/2" do
+    test "adds a device to an empty cache" do
+      cache = %DeviceCache{user_id: "u-1", devices: []}
+      device = %{token: "tok-1", platform: :ios, app: nil}
+
+      updated = DeviceCache.add_device(cache, device)
+
+      assert updated.devices == [device]
+      assert updated.user_id == "u-1"
+    end
+
+    test "appends a device when token is new" do
+      existing = %{token: "tok-1", platform: :ios, app: nil}
+      new_one = %{token: "tok-2", platform: :android, app: nil}
+      cache = %DeviceCache{user_id: "u-1", devices: [existing]}
+
+      updated = DeviceCache.add_device(cache, new_one)
+
+      assert updated.devices == [existing, new_one]
+    end
+
+    test "deduplicates by token when re-adding the same token" do
+      old = %{token: "tok-1", platform: :ios, app: "old-app"}
+      new = %{token: "tok-1", platform: :ios, app: "new-app"}
+      cache = %DeviceCache{user_id: "u-1", devices: [old]}
+
+      updated = DeviceCache.add_device(cache, new)
+
+      assert length(updated.devices) == 1
+      assert hd(updated.devices).app == "new-app"
+    end
+  end
+
+  describe "remove_device/2" do
+    test "removes a device by token" do
+      a = %{token: "tok-a", platform: :ios, app: nil}
+      b = %{token: "tok-b", platform: :android, app: nil}
+      cache = %DeviceCache{user_id: "u-1", devices: [a, b]}
+
+      updated = DeviceCache.remove_device(cache, "tok-a")
+
+      assert updated.devices == [b]
+    end
+
+    test "is a no-op when token does not exist" do
+      a = %{token: "tok-a", platform: :ios, app: nil}
+      cache = %DeviceCache{user_id: "u-1", devices: [a]}
+
+      updated = DeviceCache.remove_device(cache, "unknown")
+
+      assert updated.devices == [a]
+    end
+
+    test "works on empty cache" do
+      cache = %DeviceCache{user_id: "u-1", devices: []}
+      assert DeviceCache.remove_device(cache, "tok") == cache
+    end
+  end
+end

--- a/test/whispr_notifications/events/group_events_test.exs
+++ b/test/whispr_notifications/events/group_events_test.exs
@@ -1,0 +1,20 @@
+defmodule WhisprNotifications.Events.GroupEventsTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Events.GroupEvents
+
+  test "handle/1 processes :added events" do
+    event = %{user_id: "u-g-1", group_id: "g-1", actor_id: "a-1", action: :added}
+    assert :ok = GroupEvents.handle(event)
+  end
+
+  test "handle/1 processes :removed events" do
+    event = %{user_id: "u-g-2", group_id: "g-1", actor_id: "a-1", action: :removed}
+    assert :ok = GroupEvents.handle(event)
+  end
+
+  test "handle/1 processes :role_changed events" do
+    event = %{user_id: "u-g-3", group_id: "g-1", actor_id: "a-1", action: :role_changed}
+    assert :ok = GroupEvents.handle(event)
+  end
+end

--- a/test/whispr_notifications/events/message_events_test.exs
+++ b/test/whispr_notifications/events/message_events_test.exs
@@ -1,0 +1,17 @@
+defmodule WhisprNotifications.Events.MessageEventsTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Events.MessageEvents
+
+  test "handle_new_message/1 completes without raising for a valid event" do
+    event = %{
+      user_id: "u-msg-1",
+      conversation_id: "conv-msg-1",
+      message_id: "msg-1",
+      sender_id: "sender-1",
+      preview: "hi"
+    }
+
+    assert :ok = MessageEvents.handle_new_message(event)
+  end
+end

--- a/test/whispr_notifications/events/system_events_test.exs
+++ b/test/whispr_notifications/events/system_events_test.exs
@@ -1,0 +1,10 @@
+defmodule WhisprNotifications.Events.SystemEventsTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Events.SystemEvents
+
+  test "handle/1 processes a system event" do
+    event = %{user_id: "u-sys-1", code: "maintenance", message: "Maintenance in progress"}
+    assert :ok = SystemEvents.handle(event)
+  end
+end

--- a/test/whispr_notifications/notifications/filter_test.exs
+++ b/test/whispr_notifications/notifications/filter_test.exs
@@ -1,0 +1,18 @@
+defmodule WhisprNotifications.Notifications.FilterTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Notifications.Filter
+  alias WhisprNotifications.Test.NotificationFixtures
+
+  describe "should_send?/2" do
+    test "returns true for a default notification" do
+      notif = NotificationFixtures.build_notification()
+      assert Filter.should_send?(notif, ~U[2026-01-01 12:00:00Z])
+    end
+
+    test "returns true when called without a now argument" do
+      notif = NotificationFixtures.build_notification()
+      assert Filter.should_send?(notif)
+    end
+  end
+end

--- a/test/whispr_notifications/notifications/formatter_test.exs
+++ b/test/whispr_notifications/notifications/formatter_test.exs
@@ -1,0 +1,61 @@
+defmodule WhisprNotifications.Notifications.FormatterTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Notifications.Formatter
+  alias WhisprNotifications.Test.NotificationFixtures
+
+  describe "to_platform_payload/2 :ios" do
+    test "generates valid APNS structure" do
+      notif = NotificationFixtures.build_notification()
+      payload = Formatter.to_platform_payload(notif, :ios)
+
+      assert %{"aps" => aps} = payload
+      assert %{"alert" => %{"title" => "New message", "body" => "Hello from tests"}} = aps
+      assert aps["sound"] == "default"
+    end
+
+    test "includes notification_id in meta" do
+      notif = NotificationFixtures.build_notification(%{id: "notif-42"})
+      payload = Formatter.to_platform_payload(notif, :ios)
+
+      assert payload["meta"]["notification_id"] == "notif-42"
+    end
+
+    test "includes stringified type in meta" do
+      notif = NotificationFixtures.build_notification(%{type: :message})
+      payload = Formatter.to_platform_payload(notif, :ios)
+
+      assert payload["meta"]["type"] == "message"
+    end
+
+    test "works for all notification types" do
+      for type <- [:message, :group, :system] do
+        notif = NotificationFixtures.build_notification(%{type: type})
+        payload = Formatter.to_platform_payload(notif, :ios)
+
+        assert payload["meta"]["type"] == Atom.to_string(type)
+      end
+    end
+  end
+
+  describe "to_platform_payload/2 :android" do
+    test "generates FCM structure with atom keys" do
+      notif = NotificationFixtures.build_notification()
+      payload = Formatter.to_platform_payload(notif, :android)
+
+      assert %{notification: %{title: "New message", body: "Hello from tests"}} = payload
+      assert is_map(payload.data)
+    end
+  end
+
+  describe "to_platform_payload/2 :web" do
+    test "generates web push structure" do
+      notif = NotificationFixtures.build_notification()
+      payload = Formatter.to_platform_payload(notif, :web)
+
+      assert payload["title"] == "New message"
+      assert payload["body"] == "Hello from tests"
+      assert is_map(payload["data"])
+    end
+  end
+end

--- a/test/whispr_notifications/notifications/history_test.exs
+++ b/test/whispr_notifications/notifications/history_test.exs
@@ -1,0 +1,25 @@
+defmodule WhisprNotifications.Notifications.HistoryTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Notifications.History
+  alias WhisprNotifications.Test.NotificationFixtures
+
+  describe "save/1" do
+    test "returns :ok for a valid notification" do
+      notif = NotificationFixtures.build_notification()
+      assert :ok == History.save(notif)
+    end
+  end
+
+  describe "mark_read/2" do
+    test "returns :ok" do
+      assert :ok == History.mark_read("notif-id", DateTime.utc_now())
+    end
+  end
+
+  describe "list_for_user/1" do
+    test "returns empty list" do
+      assert [] == History.list_for_user("user-1")
+    end
+  end
+end

--- a/test/whispr_notifications/notifications/notification_test.exs
+++ b/test/whispr_notifications/notifications/notification_test.exs
@@ -1,0 +1,79 @@
+defmodule WhisprNotifications.Notifications.NotificationTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Notifications.Notification
+
+  describe "new/1" do
+    test "generates an id and created_at when not provided" do
+      notif =
+        Notification.new(%{
+          user_id: "u-1",
+          type: :message,
+          title: "t",
+          body: "b",
+          context: %{}
+        })
+
+      assert is_binary(notif.id)
+      assert %DateTime{} = notif.created_at
+      assert notif.user_id == "u-1"
+      assert notif.type == :message
+    end
+
+    test "keeps explicit id and created_at" do
+      dt = ~U[2026-01-01 00:00:00Z]
+
+      notif =
+        Notification.new(%{
+          id: "fixed-id",
+          user_id: "u-1",
+          type: :system,
+          title: "t",
+          body: "b",
+          context: %{},
+          created_at: dt
+        })
+
+      assert notif.id == "fixed-id"
+      assert notif.created_at == dt
+    end
+
+    test "raises when required keys are missing" do
+      assert_raise ArgumentError, fn ->
+        Notification.new(%{user_id: "u-1"})
+      end
+    end
+  end
+
+  describe "mark_read/2" do
+    test "sets read_at to the given datetime" do
+      notif =
+        Notification.new(%{
+          user_id: "u-1",
+          type: :message,
+          title: "t",
+          body: "b",
+          context: %{}
+        })
+
+      at = ~U[2026-01-02 10:00:00Z]
+      updated = Notification.mark_read(notif, at)
+
+      assert updated.read_at == at
+    end
+
+    test "defaults to DateTime.utc_now/0 when not given" do
+      notif =
+        Notification.new(%{
+          user_id: "u-1",
+          type: :message,
+          title: "t",
+          body: "b",
+          context: %{}
+        })
+
+      updated = Notification.mark_read(notif)
+      assert %DateTime{} = updated.read_at
+    end
+  end
+end

--- a/test/whispr_notifications/notifications_test.exs
+++ b/test/whispr_notifications/notifications_test.exs
@@ -1,0 +1,134 @@
+defmodule WhisprNotifications.NotificationsTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Notifications
+  alias WhisprNotifications.Notifications.Notification
+
+  describe "create/1 success" do
+    test "returns an ok tuple with a valid notification (string keys)" do
+      assert {:ok, %Notification{} = notif} =
+               Notifications.create(%{
+                 "user_id" => "u-ok-1",
+                 "type" => "message",
+                 "title" => "Hello",
+                 "body" => "World",
+                 "context" => %{"conversation_id" => "c-1"},
+                 "conversation_id" => "c-1"
+               })
+
+      assert notif.type == :message
+      assert notif.title == "Hello"
+      assert notif.body == "World"
+      assert notif.user_id == "u-ok-1"
+      assert notif.conversation_id == "c-1"
+      assert is_binary(notif.id)
+      assert %DateTime{} = notif.created_at
+    end
+
+    test "accepts atom keys and atom type" do
+      assert {:ok, %Notification{type: :group}} =
+               Notifications.create(%{
+                 user_id: "u-ok-2",
+                 type: :group,
+                 title: "t",
+                 body: "b",
+                 context: %{foo: "bar"}
+               })
+    end
+
+    test "defaults context to an empty map when missing" do
+      assert {:ok, %Notification{context: ctx}} =
+               Notifications.create(%{
+                 user_id: "u-ok-3",
+                 type: "system",
+                 title: "t",
+                 body: "b"
+               })
+
+      assert ctx == %{}
+    end
+
+    test "stringifies atom-keyed context" do
+      assert {:ok, %Notification{context: %{"foo" => "bar"}}} =
+               Notifications.create(%{
+                 user_id: "u-ok-4",
+                 type: "system",
+                 title: "t",
+                 body: "b",
+                 context: %{foo: "bar"}
+               })
+    end
+
+    test "parses each valid type string" do
+      for {str, atom} <- [{"message", :message}, {"group", :group}, {"system", :system}] do
+        assert {:ok, %Notification{type: ^atom}} =
+                 Notifications.create(%{
+                   user_id: "u-ok-types",
+                   type: str,
+                   title: "t",
+                   body: "b"
+                 })
+      end
+    end
+  end
+
+  describe "create/1 validation errors" do
+    test "rejects missing user_id" do
+      assert {:error, :validation, errs} =
+               Notifications.create(%{
+                 "type" => "message",
+                 "title" => "t",
+                 "body" => "b"
+               })
+
+      assert "user_id est requis" in errs
+    end
+
+    test "rejects missing title and body" do
+      assert {:error, :validation, errs} =
+               Notifications.create(%{
+                 "user_id" => "u",
+                 "type" => "message"
+               })
+
+      assert "title est requis" in errs
+      assert "body est requis" in errs
+    end
+
+    test "rejects invalid type" do
+      assert {:error, :validation, errs} =
+               Notifications.create(%{
+                 "user_id" => "u",
+                 "type" => "nonsense",
+                 "title" => "t",
+                 "body" => "b"
+               })
+
+      assert "type doit être message, group ou system" in errs
+    end
+
+    test "rejects missing type" do
+      assert {:error, :validation, errs} =
+               Notifications.create(%{
+                 "user_id" => "u",
+                 "title" => "t",
+                 "body" => "b"
+               })
+
+      assert "type est requis" in errs
+    end
+
+    test "silently defaults non-map context to an empty map" do
+      assert {:ok, notif} =
+               Notifications.create(%{
+                 "user_id" => "u",
+                 "type" => "message",
+                 "title" => "t",
+                 "body" => "b",
+                 "context" => "not-a-map"
+               })
+
+      assert notif.context == %{}
+    end
+  end
+end

--- a/test/whispr_notifications/preferences/conversation_settings_test.exs
+++ b/test/whispr_notifications/preferences/conversation_settings_test.exs
@@ -1,0 +1,39 @@
+defmodule WhisprNotifications.Preferences.ConversationSettingsTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Preferences.ConversationSettings
+
+  describe "muted_now?/2" do
+    test "returns false when not muted" do
+      s = %ConversationSettings{user_id: "u", conversation_id: "c", muted: false}
+      refute ConversationSettings.muted_now?(s, ~U[2026-01-01 00:00:00Z])
+    end
+
+    test "returns true when muted indefinitely (mute_until nil)" do
+      s = %ConversationSettings{user_id: "u", conversation_id: "c", muted: true}
+      assert ConversationSettings.muted_now?(s, ~U[2026-01-01 00:00:00Z])
+    end
+
+    test "returns true when muted with mute_until in the future" do
+      s = %ConversationSettings{
+        user_id: "u",
+        conversation_id: "c",
+        muted: true,
+        mute_until: ~U[2026-06-01 00:00:00Z]
+      }
+
+      assert ConversationSettings.muted_now?(s, ~U[2026-01-01 00:00:00Z])
+    end
+
+    test "returns false when mute_until is in the past" do
+      s = %ConversationSettings{
+        user_id: "u",
+        conversation_id: "c",
+        muted: true,
+        mute_until: ~U[2025-01-01 00:00:00Z]
+      }
+
+      refute ConversationSettings.muted_now?(s, ~U[2026-01-01 00:00:00Z])
+    end
+  end
+end

--- a/test/whispr_notifications/preferences/manager_test.exs
+++ b/test/whispr_notifications/preferences/manager_test.exs
@@ -1,0 +1,31 @@
+defmodule WhisprNotifications.Preferences.ManagerTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Preferences.{Manager, UserSettings, ConversationSettings}
+  alias WhisprNotifications.Test.NotificationFixtures
+
+  describe "get_user_settings/1" do
+    test "returns default UserSettings struct" do
+      assert {:ok, %UserSettings{user_id: "u-1"}} = Manager.get_user_settings("u-1")
+    end
+  end
+
+  describe "get_conversation_settings/2" do
+    test "returns default ConversationSettings struct" do
+      assert {:ok, %ConversationSettings{user_id: "u-1", conversation_id: "c-2"}} =
+               Manager.get_conversation_settings("u-1", "c-2")
+    end
+  end
+
+  describe "allowed_for_notification?/2" do
+    test "returns true for a notification with default settings" do
+      notif = NotificationFixtures.build_notification()
+      assert Manager.allowed_for_notification?(notif, ~U[2026-01-01 10:00:00Z])
+    end
+
+    test "uses DateTime.utc_now/0 when no now is passed" do
+      notif = NotificationFixtures.build_notification()
+      assert Manager.allowed_for_notification?(notif)
+    end
+  end
+end

--- a/test/whispr_notifications/preferences/user_settings_test.exs
+++ b/test/whispr_notifications/preferences/user_settings_test.exs
@@ -1,0 +1,104 @@
+defmodule WhisprNotifications.Preferences.UserSettingsTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.Preferences.UserSettings
+
+  describe "quiet_now?/2 (no quiet hours)" do
+    test "returns false when both start/end are nil" do
+      settings = %UserSettings{user_id: "u-1"}
+      refute UserSettings.quiet_now?(settings, ~U[2026-01-01 12:00:00Z])
+    end
+  end
+
+  describe "quiet_now?/2 same-day window" do
+    setup do
+      settings = %UserSettings{
+        user_id: "u-1",
+        quiet_hours_start: ~T[09:00:00],
+        quiet_hours_end: ~T[17:00:00]
+      }
+
+      {:ok, settings: settings}
+    end
+
+    test "returns true at the beginning of the window", %{settings: s} do
+      assert UserSettings.quiet_now?(s, ~U[2026-01-01 09:00:00Z])
+    end
+
+    test "returns true in the middle of the window", %{settings: s} do
+      assert UserSettings.quiet_now?(s, ~U[2026-01-01 12:30:00Z])
+    end
+
+    test "returns true at the end of the window", %{settings: s} do
+      assert UserSettings.quiet_now?(s, ~U[2026-01-01 17:00:00Z])
+    end
+
+    test "returns false before the window", %{settings: s} do
+      refute UserSettings.quiet_now?(s, ~U[2026-01-01 08:59:59Z])
+    end
+
+    test "returns false after the window", %{settings: s} do
+      refute UserSettings.quiet_now?(s, ~U[2026-01-01 17:00:01Z])
+    end
+  end
+
+  describe "quiet_now?/2 midnight-crossing window" do
+    setup do
+      settings = %UserSettings{
+        user_id: "u-1",
+        quiet_hours_start: ~T[22:00:00],
+        quiet_hours_end: ~T[07:00:00]
+      }
+
+      {:ok, settings: settings}
+    end
+
+    test "returns true late in the evening", %{settings: s} do
+      assert UserSettings.quiet_now?(s, ~U[2026-01-01 23:30:00Z])
+    end
+
+    test "returns true early in the morning", %{settings: s} do
+      assert UserSettings.quiet_now?(s, ~U[2026-01-01 05:00:00Z])
+    end
+
+    test "returns false during the day", %{settings: s} do
+      refute UserSettings.quiet_now?(s, ~U[2026-01-01 12:00:00Z])
+    end
+  end
+
+  describe "quiet_now?/2 with timezone" do
+    test "shifts the comparison into the given timezone" do
+      settings = %UserSettings{
+        user_id: "u-1",
+        timezone: "Etc/UTC",
+        quiet_hours_start: ~T[09:00:00],
+        quiet_hours_end: ~T[17:00:00]
+      }
+
+      assert UserSettings.quiet_now?(settings, ~U[2026-01-01 12:00:00Z])
+      refute UserSettings.quiet_now?(settings, ~U[2026-01-01 18:00:00Z])
+    end
+  end
+
+  describe "quiet_now?/2 defensive branches" do
+    test "returns false when only start is nil" do
+      settings = %UserSettings{
+        user_id: "u-1",
+        quiet_hours_start: nil,
+        quiet_hours_end: ~T[07:00:00]
+      }
+
+      refute UserSettings.quiet_now?(settings, ~U[2026-01-01 12:00:00Z])
+    end
+
+    test "returns false when only end is nil" do
+      settings = %UserSettings{
+        user_id: "u-1",
+        quiet_hours_start: ~T[22:00:00],
+        quiet_hours_end: nil
+      }
+
+      refute UserSettings.quiet_now?(settings, ~U[2026-01-01 12:00:00Z])
+    end
+  end
+end

--- a/test/whispr_notifications/workers/cache_sync_worker_test.exs
+++ b/test/whispr_notifications/workers/cache_sync_worker_test.exs
@@ -1,0 +1,13 @@
+defmodule WhisprNotifications.Workers.CacheSyncWorkerTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Workers.CacheSyncWorker
+
+  test "is started under the app supervisor and handles :sync" do
+    pid = Process.whereis(CacheSyncWorker)
+    assert is_pid(pid)
+
+    send(pid, :sync)
+    assert :sys.get_state(pid) == %{}
+  end
+end

--- a/test/whispr_notifications/workers/cleanup_worker_test.exs
+++ b/test/whispr_notifications/workers/cleanup_worker_test.exs
@@ -1,0 +1,13 @@
+defmodule WhisprNotifications.Workers.CleanupWorkerTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Workers.CleanupWorker
+
+  test "is started under the app supervisor and handles :cleanup" do
+    pid = Process.whereis(CleanupWorker)
+    assert is_pid(pid)
+
+    send(pid, :cleanup)
+    assert :sys.get_state(pid) == %{}
+  end
+end

--- a/test/whispr_notifications/workers/metrics_worker_test.exs
+++ b/test/whispr_notifications/workers/metrics_worker_test.exs
@@ -1,0 +1,13 @@
+defmodule WhisprNotifications.Workers.MetricsWorkerTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Workers.MetricsWorker
+
+  test "is started under the app supervisor and handles :tick" do
+    pid = Process.whereis(MetricsWorker)
+    assert is_pid(pid)
+
+    send(pid, :tick)
+    assert :sys.get_state(pid) == %{}
+  end
+end

--- a/test/whispr_notifications/workers/moderation_subscriber_test.exs
+++ b/test/whispr_notifications/workers/moderation_subscriber_test.exs
@@ -1,0 +1,106 @@
+defmodule WhisprNotifications.Workers.ModerationSubscriberTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Workers.ModerationSubscriber
+
+  test "is started under the app supervisor and holds state" do
+    pid = Process.whereis(ModerationSubscriber)
+    assert is_pid(pid)
+    assert Process.alive?(pid)
+
+    state = :sys.get_state(pid)
+    assert is_map(state)
+    assert Map.has_key?(state, :pubsub)
+  end
+
+  test "dispatches a :message handle_info event to the moderation handlers (JSON valid)" do
+    pid = Process.whereis(ModerationSubscriber)
+    payload = Jason.encode!(%{"user_id" => "u-moderation-sub", "sanction_id" => "s-1"})
+
+    send(
+      pid,
+      {:redix_pubsub, nil, nil, :message,
+       %{channel: "whispr:moderation:sanction_lifted", payload: payload}}
+    )
+
+    # GenServer should remain alive
+    assert Process.alive?(pid)
+  end
+
+  test "tolerates malformed JSON payloads without crashing" do
+    pid = Process.whereis(ModerationSubscriber)
+
+    send(
+      pid,
+      {:redix_pubsub, nil, nil, :message,
+       %{channel: "whispr:moderation:report_created", payload: "not-json"}}
+    )
+
+    assert Process.alive?(pid)
+  end
+
+  test "ignores unknown channels without crashing" do
+    pid = Process.whereis(ModerationSubscriber)
+    payload = Jason.encode!(%{"x" => 1})
+
+    send(
+      pid,
+      {:redix_pubsub, nil, nil, :message,
+       %{channel: "whispr:moderation:unknown-channel", payload: payload}}
+    )
+
+    assert Process.alive?(pid)
+  end
+
+  test "ignores :subscribed acks" do
+    pid = Process.whereis(ModerationSubscriber)
+
+    send(
+      pid,
+      {:redix_pubsub, nil, nil, :subscribed, %{channel: "whispr:moderation:report_created"}}
+    )
+
+    assert Process.alive?(pid)
+  end
+
+  test "ignores unrelated messages" do
+    pid = Process.whereis(ModerationSubscriber)
+    send(pid, :unrelated)
+    assert Process.alive?(pid)
+  end
+
+  test "routes to every moderation handler (happy payloads)" do
+    pid = Process.whereis(ModerationSubscriber)
+
+    routed = [
+      {"whispr:moderation:report_created",
+       %{"report_id" => "r", "reporter_id" => "u1", "reported_user_id" => "u2", "category" => "c"}},
+      {"whispr:moderation:sanction_applied",
+       %{
+         "user_id" => "u",
+         "sanction_type" => "mute",
+         "reason" => "x",
+         "expires_at" => nil
+       }},
+      {"whispr:moderation:sanction_lifted", %{"user_id" => "u", "sanction_id" => "s"}},
+      {"whispr:moderation:appeal_created",
+       %{"appeal_id" => "a", "user_id" => "u", "sanction_id" => "s"}},
+      {"whispr:moderation:appeal_resolved",
+       %{"appeal_id" => "a", "user_id" => "u", "status" => "accepted", "reviewer_notes" => nil}},
+      {"whispr:moderation:threshold_reached",
+       %{"reported_user_id" => "u", "threshold_level" => "high", "report_count" => 3}}
+    ]
+
+    for {channel, payload} <- routed do
+      send(
+        pid,
+        {:redix_pubsub, nil, nil, :message,
+         %{channel: channel, payload: Jason.encode!(payload)}}
+      )
+    end
+
+    # Let async Tasks run briefly, then confirm process still alive
+    Process.sleep(100)
+    assert Process.alive?(pid)
+  end
+end

--- a/test/whispr_notifications/workers/token_refresher_test.exs
+++ b/test/whispr_notifications/workers/token_refresher_test.exs
@@ -1,0 +1,14 @@
+defmodule WhisprNotifications.Workers.TokenRefresherTest do
+  use ExUnit.Case, async: false
+
+  alias WhisprNotifications.Workers.TokenRefresher
+
+  test "is started under the app supervisor and accepts :refresh_tokens" do
+    pid = Process.whereis(TokenRefresher)
+    assert is_pid(pid)
+    assert Process.alive?(pid)
+
+    send(pid, :refresh_tokens)
+    assert :sys.get_state(pid) == %{}
+  end
+end

--- a/test/whispr_notifications_web/controllers/error_html_test.exs
+++ b/test/whispr_notifications_web/controllers/error_html_test.exs
@@ -1,0 +1,13 @@
+defmodule WhisprNotificationsWeb.ErrorHTMLTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotificationsWeb.ErrorHTML
+
+  test "renders a templated error string" do
+    assert ErrorHTML.render("404.html", %{}) == "Error: Not Found"
+  end
+
+  test "renders 500" do
+    assert ErrorHTML.render("500.html", %{}) == "Error: Internal Server Error"
+  end
+end

--- a/test/whispr_notifications_web/controllers/error_json_test.exs
+++ b/test/whispr_notifications_web/controllers/error_json_test.exs
@@ -1,0 +1,29 @@
+defmodule WhisprNotificationsWeb.ErrorJSONTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotificationsWeb.ErrorJSON
+
+  test "renders 400" do
+    assert ErrorJSON.render("400.json", %{}) == %{errors: %{detail: "Bad Request"}}
+  end
+
+  test "renders 401" do
+    assert ErrorJSON.render("401.json", %{}) == %{errors: %{detail: "Unauthorized"}}
+  end
+
+  test "renders 403" do
+    assert ErrorJSON.render("403.json", %{}) == %{errors: %{detail: "Forbidden"}}
+  end
+
+  test "renders 404" do
+    assert ErrorJSON.render("404.json", %{}) == %{errors: %{detail: "Not Found"}}
+  end
+
+  test "renders 500" do
+    assert ErrorJSON.render("500.json", %{}) == %{errors: %{detail: "Internal Server Error"}}
+  end
+
+  test "renders an arbitrary template via Phoenix fallback" do
+    assert %{errors: %{detail: _}} = ErrorJSON.render("418.json", %{})
+  end
+end

--- a/test/whispr_notifications_web/controllers/fallback_controller_test.exs
+++ b/test/whispr_notifications_web/controllers/fallback_controller_test.exs
@@ -1,0 +1,21 @@
+defmodule WhisprNotificationsWeb.FallbackControllerTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+
+  alias WhisprNotificationsWeb.FallbackController
+
+  test "call/2 with :not_found returns 404" do
+    conn = :get |> conn("/") |> FallbackController.call({:error, :not_found})
+    assert conn.status == 404
+  end
+
+  test "call/2 with :bad_request returns 400" do
+    conn = :get |> conn("/") |> FallbackController.call({:error, :bad_request})
+    assert conn.status == 400
+  end
+
+  test "call/2 with unknown error returns 500" do
+    conn = :get |> conn("/") |> FallbackController.call({:error, :kaboom})
+    assert conn.status == 500
+  end
+end

--- a/test/whispr_notifications_web/controllers/mute_controller_test.exs
+++ b/test/whispr_notifications_web/controllers/mute_controller_test.exs
@@ -1,0 +1,34 @@
+defmodule WhisprNotificationsWeb.MuteControllerTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+
+  alias WhisprNotificationsWeb.MuteController
+  alias WhisprNotificationsWeb.Router
+
+  test "POST /api/conversations/:id/mute returns 204 when user_id is in body" do
+    conn =
+      :post
+      |> conn("/api/conversations/conv-1/mute", %{"user_id" => "u-1"})
+      |> Router.call([])
+
+    assert conn.status == 204
+  end
+
+  test "MuteController.mute/2 returns 204 directly" do
+    conn =
+      :post
+      |> conn("/api/conversations/conv-1/mute")
+      |> MuteController.mute(%{"conversation_id" => "conv-1", "user_id" => "u-1"})
+
+    assert conn.status == 204
+  end
+
+  test "MuteController.unmute/2 returns 204 directly" do
+    conn =
+      :delete
+      |> conn("/api/conversations/conv-1/mute")
+      |> MuteController.unmute(%{"conversation_id" => "conv-1", "user_id" => "u-1"})
+
+    assert conn.status == 204
+  end
+end

--- a/test/whispr_notifications_web/controllers/notifications_controller_test.exs
+++ b/test/whispr_notifications_web/controllers/notifications_controller_test.exs
@@ -1,0 +1,110 @@
+defmodule WhisprNotificationsWeb.NotificationsControllerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias WhisprNotifications.Auth.JwksCache
+  alias WhisprNotifications.Test.ES256JwtFixtures
+  alias WhisprNotificationsWeb.Router
+
+  setup do
+    jwks_key = ES256JwtFixtures.primary_jwks_public_entry()
+    http_get_fun = fn _url -> {:ok, %{status: 200, body: %{"keys" => [jwks_key]}}} end
+    server = :jwks_cache_notif_ctrl_test
+
+    original = Application.get_env(:whispr_notification, :jwt)
+
+    Application.put_env(
+      :whispr_notification,
+      :jwt,
+      jwks_url: "http://auth-service/auth/.well-known/jwks.json",
+      issuer: "whispr-auth",
+      audience: "whispr-notification",
+      allowed_algs: ["ES256"],
+      jwks_refresh_interval_ms: 60_000,
+      jwks_cache_server: server
+    )
+
+    start_supervised!({JwksCache, [name: server, http_get_fun: http_get_fun]})
+
+    token = sign_token(ES256JwtFixtures.primary_private_jwk(), ES256JwtFixtures.primary_kid())
+
+    on_exit(fn ->
+      if original == nil do
+        Application.delete_env(:whispr_notification, :jwt)
+      else
+        Application.put_env(:whispr_notification, :jwt, original)
+      end
+    end)
+
+    {:ok, token: token}
+  end
+
+  test "POST /api/v1/notifications returns 201 with serialized notification", %{token: token} do
+    body = %{
+      "user_id" => "ctrl-u-1",
+      "type" => "message",
+      "title" => "Hi",
+      "body" => "There",
+      "context" => %{"conversation_id" => "c-1"}
+    }
+
+    conn =
+      :post
+      |> conn("/api/v1/notifications", body)
+      |> put_req_header("authorization", "Bearer " <> token)
+      |> put_req_header("content-type", "application/json")
+      |> Router.call([])
+
+    assert conn.status == 201
+    decoded = Jason.decode!(conn.resp_body)
+    assert decoded["user_id"] == "ctrl-u-1"
+    assert decoded["type"] == "message"
+    assert decoded["title"] == "Hi"
+    assert is_binary(decoded["id"])
+    assert is_binary(decoded["created_at"])
+  end
+
+  test "POST /api/v1/notifications returns 400 on validation errors", %{token: token} do
+    conn =
+      :post
+      |> conn("/api/v1/notifications", %{"type" => "message"})
+      |> put_req_header("authorization", "Bearer " <> token)
+      |> put_req_header("content-type", "application/json")
+      |> Router.call([])
+
+    assert conn.status == 400
+    decoded = Jason.decode!(conn.resp_body)
+    assert is_list(decoded["errors"])
+    assert "user_id est requis" in decoded["errors"]
+  end
+
+  test "POST /api/v1/notifications returns 401 without a bearer token" do
+    conn =
+      :post
+      |> conn("/api/v1/notifications", %{"user_id" => "u"})
+      |> put_req_header("content-type", "application/json")
+      |> Router.call([])
+
+    assert conn.status == 401
+    assert Jason.decode!(conn.resp_body) == %{"error" => "unauthorized"}
+  end
+
+  defp sign_token(priv, kid) do
+    now = System.system_time(:second)
+
+    claims = %{
+      "sub" => "user-ctrl",
+      "iss" => "whispr-auth",
+      "aud" => "whispr-notification",
+      "exp" => now + 3600
+    }
+
+    {_, token} =
+      priv
+      |> JOSE.JWT.sign(%{"alg" => "ES256", "kid" => kid}, claims)
+      |> JOSE.JWS.compact()
+
+    token
+  end
+end

--- a/test/whispr_notifications_web/controllers/settings_controller_test.exs
+++ b/test/whispr_notifications_web/controllers/settings_controller_test.exs
@@ -1,0 +1,30 @@
+defmodule WhisprNotificationsWeb.SettingsControllerTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+
+  alias WhisprNotificationsWeb.Router
+
+  test "GET /api/settings/:id returns user settings JSON" do
+    conn =
+      :get
+      |> conn("/api/settings/user-settings-1")
+      |> Router.call([])
+
+    assert conn.status == 200
+    decoded = Jason.decode!(conn.resp_body)
+    assert decoded["user_id"] == "user-settings-1"
+    assert decoded["message_push_enabled"] == true
+    assert decoded["message_email_enabled"] == false
+    assert decoded["system_push_enabled"] == true
+    assert decoded["marketing_push_enabled"] == false
+  end
+
+  test "PUT /api/settings/:id returns 204" do
+    conn =
+      :put
+      |> conn("/api/settings/user-settings-2", %{"message_push_enabled" => false})
+      |> Router.call([])
+
+    assert conn.status == 204
+  end
+end

--- a/test/whispr_notifications_web/plugs/authenticate_test.exs
+++ b/test/whispr_notifications_web/plugs/authenticate_test.exs
@@ -1,0 +1,107 @@
+defmodule WhisprNotificationsWeb.Plugs.AuthenticateTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias WhisprNotifications.Auth.JwksCache
+  alias WhisprNotifications.Test.ES256JwtFixtures
+  alias WhisprNotificationsWeb.Plugs.Authenticate
+
+  @opts Authenticate.init([])
+
+  setup do
+    jwks_key = ES256JwtFixtures.primary_jwks_public_entry()
+    http_get_fun = fn _url -> {:ok, %{status: 200, body: %{"keys" => [jwks_key]}}} end
+    server = :jwks_cache_plug_authn_test
+
+    original = Application.get_env(:whispr_notification, :jwt)
+
+    Application.put_env(
+      :whispr_notification,
+      :jwt,
+      jwks_url: "http://auth-service/auth/.well-known/jwks.json",
+      issuer: "whispr-auth",
+      audience: "whispr-notification",
+      allowed_algs: ["ES256"],
+      jwks_cache_server: server
+    )
+
+    start_supervised!({JwksCache, [name: server, http_get_fun: http_get_fun]})
+
+    on_exit(fn ->
+      if original == nil do
+        Application.delete_env(:whispr_notification, :jwt)
+      else
+        Application.put_env(:whispr_notification, :jwt, original)
+      end
+    end)
+
+    :ok
+  end
+
+  test "init/1 returns its opts" do
+    assert Authenticate.init(foo: 1) == [foo: 1]
+  end
+
+  test "returns 401 when no Authorization header" do
+    conn = :get |> conn("/") |> Authenticate.call(@opts)
+    assert conn.status == 401
+    assert conn.halted
+    assert Jason.decode!(conn.resp_body) == %{"error" => "unauthorized"}
+  end
+
+  test "returns 401 when Authorization header is malformed" do
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("authorization", "Token abc")
+      |> Authenticate.call(@opts)
+
+    assert conn.status == 401
+    assert conn.halted
+  end
+
+  test "returns 401 for invalid Bearer token" do
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("authorization", "Bearer not-a-token")
+      |> Authenticate.call(@opts)
+
+    assert conn.status == 401
+    assert conn.halted
+  end
+
+  test "assigns jwt_claims and jwt_sub for a valid token" do
+    token =
+      sign_token(ES256JwtFixtures.primary_private_jwk(), ES256JwtFixtures.primary_kid())
+
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("authorization", "Bearer " <> token)
+      |> Authenticate.call(@opts)
+
+    refute conn.halted
+    assert conn.assigns.jwt_sub == "user-authn-test"
+    assert is_map(conn.assigns.jwt_claims)
+  end
+
+  defp sign_token(priv, kid) do
+    now = System.system_time(:second)
+
+    claims = %{
+      "sub" => "user-authn-test",
+      "iss" => "whispr-auth",
+      "aud" => "whispr-notification",
+      "exp" => now + 3600
+    }
+
+    {_, token} =
+      priv
+      |> JOSE.JWT.sign(%{"alg" => "ES256", "kid" => kid}, claims)
+      |> JOSE.JWS.compact()
+
+    token
+  end
+end

--- a/test/whispr_notifications_web/router_test.exs
+++ b/test/whispr_notifications_web/router_test.exs
@@ -1,0 +1,52 @@
+defmodule WhisprNotificationsWeb.RouterTest do
+  @moduledoc """
+  Covers the alternate `/notification/api` scope kept for gateways that forward
+  the full path without stripping the `/notification` prefix.
+  """
+  use ExUnit.Case, async: true
+  import Plug.Test
+
+  alias WhisprNotificationsWeb.{MuteController, Router}
+
+  test "GET /notification/api/v1/health returns 200" do
+    conn = :get |> conn("/notification/api/v1/health") |> Router.call([])
+    assert conn.status == 200
+  end
+
+  test "GET /notification/api/settings/:id returns 200" do
+    conn = :get |> conn("/notification/api/settings/u-alt") |> Router.call([])
+    assert conn.status == 200
+  end
+
+  test "PUT /notification/api/settings/:id returns 204" do
+    conn =
+      :put
+      |> conn("/notification/api/settings/u-alt", %{"foo" => "bar"})
+      |> Router.call([])
+
+    assert conn.status == 204
+  end
+
+  test "POST /notification/api/conversations/:id/mute returns 204" do
+    conn =
+      :post
+      |> conn("/notification/api/conversations/conv-1/mute", %{"user_id" => "u-1"})
+      |> Router.call([])
+
+    assert conn.status == 204
+  end
+
+  test "DELETE mute via controller directly (alt scope parity)" do
+    conn =
+      :delete
+      |> conn("/notification/api/conversations/conv-1/mute")
+      |> MuteController.unmute(%{"conversation_id" => "conv-1", "user_id" => "u-1"})
+
+    assert conn.status == 204
+  end
+
+  test "GET /notification/api/v1/auth-check returns 401 without JWT" do
+    conn = :get |> conn("/notification/api/v1/auth-check") |> Router.call([])
+    assert conn.status == 401
+  end
+end


### PR DESCRIPTION
## Summary
  - Ajout de **24 fichiers de tests** (unitaires + intégration) couvrant l'ensemble des modules domain, web et workers.
  - Couverture passe de **53.8 % → 90.1 %** (**161 tests, 0 failure**).
  - Fix de 2 bugs bloquants révélés par les tests :
    - `MessageEvents.handle_new_message/1` : `event.manager_id` → `event.message_id` (typo qui levait `KeyError`).
    - `GroupEvents.handle/1` : ajout du `context` manquant (crash sur `@enforce_keys` de `Notification`).

  ## Détails

  ### Nouveaux tests par domaine

  | Domaine | Fichiers | Cibles |
  |---------|----------|--------|
  | Auth | `jwks_test.exs`, `jwks_cache_extra_test.exs`, `jwt_verifier_extra_test.exs` | Parsing JWKS, HTTP errors, exp/iss/aud/invalid header/alg |
  | Delivery | `fcm_client_test.exs` | FCM stub |
  | Devices | `device_cache_test.exs`, `auth_client_test.exs`, `cache_manager_test.exs` | Add/remove/dedup device, lazy cache fetch |
  | Events | `message_events_test.exs`, `group_events_test.exs`, `system_events_test.exs` | Happy path des 3 handlers |
  | Notifications | `notification_test.exs`, `filter_test.exs`, `notifications_test.exs` | Struct, validation, should_send?, create/1 (succès + erreurs) |
  | Preferences | `user_settings_test.exs`, `conversation_settings_test.exs`, `manager_test.exs` | quiet_hours (intra-jour / minuit-crossing / timezone), mute |
  | Workers | `token_refresher_test.exs`, `cache_sync_worker_test.exs`, `cleanup_worker_test.exs`, `metrics_worker_test.exs`, `moderation_subscriber_test.exs` |
  GenServers supervisés, routing Redis Pub/Sub |
  | Web | `notifications_controller_test.exs`, `settings_controller_test.exs`, `mute_controller_test.exs`, `fallback_controller_test.exs`, `error_json_test.exs`,
  `error_html_test.exs`, `authenticate_test.exs`, `router_test.exs` | 201/400/401/403, dual scope `/notification/api/*` |

  ### Couverture par module clé

   90.9% auth/jwks_cache.ex
   86.0% auth/jwt_verifier.ex
  100.0% delivery/{apns,batch,fcm,retry}
  100.0% devices/device_cache.ex
  100.0% events/{group,message,system}_events.ex
   92.3% events/moderation_events.ex
   89.7% notifications.ex
  100.0% preferences/{user,conversation,manager}_settings.ex
  100.0% plugs/authenticate.ex
   78.5% router.ex
  [TOTAL]  90.1%