### PR TITLE
chore(ci): auto fast-forward deploy/preprod with main on infra sync

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -222,3 +222,20 @@ jobs:
 
           git pull origin "${INFRA_BRANCH}" --rebase
           git push https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/whispr-messenger/infrastructure.git HEAD:"${INFRA_BRANCH}"
+
+      - name: Fast-forward deploy/preprod with main on infrastructure repo
+        if: steps.branch_info.outputs.infra_branch == 'main'
+        env:
+          INFRA_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          # When the trigger branch is main, infra/main has been updated above.
+          # ArgoCD preprod tracks infra/deploy/preprod, so fast-forward it from main.
+          # Fast-forward only — never force-push, never delete the branch.
+          git fetch origin main deploy/preprod
+          git checkout deploy/preprod
+          if git merge --ff-only origin/main; then
+            git push "https://x-access-token:${INFRA_TOKEN}@github.com/whispr-messenger/infrastructure.git" deploy/preprod
+            echo "✅ deploy/preprod fast-forwarded to main"
+          else
+            echo "::warning::Cannot fast-forward deploy/preprod from main (diverged). Manual merge required."
+          fi


### PR DESCRIPTION
## Summary
Adds an automatic fast-forward step in the CD workflow so that after the infrastructure repo's `main` branch is updated, `deploy/preprod` is fast-forwarded to match. ArgoCD preprod tracks `deploy/preprod` so this removes the need for manual sync.

Fast-forward only — no force-push, no branch deletion. Falls back to a GitHub Actions warning if the branch has diverged.