### PR TITLE
feat(moderation): forward blocked image appeal decisions to users

### DIFF
--- a/lib/whispr_notifications/events/moderation_events.ex
+++ b/lib/whispr_notifications/events/moderation_events.ex
@@ -9,6 +9,8 @@ defmodule WhisprNotifications.Events.ModerationEvents do
   - whispr:moderation:appeal_created
   - whispr:moderation:appeal_resolved
   - whispr:moderation:threshold_reached
+  - whispr:moderation:blocked_image_approved
+  - whispr:moderation:blocked_image_rejected
   """
 
   require Logger
@@ -179,6 +181,52 @@ defmodule WhisprNotifications.Events.ModerationEvents do
       })
 
     Logger.info("[ModerationEvents] Threshold warning for user #{payload["reported_user_id"]}")
+
+    result
+  end
+
+  @doc "Notify a user when their blocked image appeal has been reviewed."
+  @spec handle_blocked_image_decision(map(), String.t()) ::
+          {:ok, Notification.t()} | {:error, term()}
+  def handle_blocked_image_decision(payload, decision)
+      when decision in ["approved", "rejected"] do
+    {title, body} =
+      case decision do
+        "approved" ->
+          {"Image appeal approved",
+           "Your contested image has been approved and will be delivered."}
+
+        "rejected" ->
+          {"Image appeal rejected",
+           String.trim(
+             "Your contested image has been rejected. #{payload["reviewerNotes"] || ""}"
+           )}
+      end
+
+    context =
+      %{
+        "event" => "blocked_image_decision",
+        "appealId" => payload["appealId"],
+        "decision" => decision,
+        "messageTempId" => payload["messageTempId"],
+        "conversationId" => payload["conversationId"],
+        "reason" => payload["reviewerNotes"]
+      }
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+
+    result =
+      Notifications.create(%{
+        user_id: payload["userId"],
+        type: :system,
+        title: title,
+        body: body,
+        context: context
+      })
+
+    Logger.info(
+      "[ModerationEvents] Blocked image appeal #{decision} notification sent to user #{payload["userId"]} (appeal=#{payload["appealId"]})"
+    )
 
     result
   end

--- a/lib/whispr_notifications/workers/moderation_subscriber.ex
+++ b/lib/whispr_notifications/workers/moderation_subscriber.ex
@@ -15,7 +15,9 @@ defmodule WhisprNotifications.Workers.ModerationSubscriber do
     "whispr:moderation:sanction_lifted",
     "whispr:moderation:appeal_created",
     "whispr:moderation:appeal_resolved",
-    "whispr:moderation:threshold_reached"
+    "whispr:moderation:threshold_reached",
+    "whispr:moderation:blocked_image_approved",
+    "whispr:moderation:blocked_image_rejected"
   ]
 
   def start_link(opts) do
@@ -114,6 +116,12 @@ defmodule WhisprNotifications.Workers.ModerationSubscriber do
 
   defp route_event("whispr:moderation:threshold_reached", payload),
     do: ModerationEvents.handle_threshold_warning(payload)
+
+  defp route_event("whispr:moderation:blocked_image_approved", payload),
+    do: ModerationEvents.handle_blocked_image_decision(payload, "approved")
+
+  defp route_event("whispr:moderation:blocked_image_rejected", payload),
+    do: ModerationEvents.handle_blocked_image_decision(payload, "rejected")
 
   defp route_event(channel, _payload),
     do: Logger.warning("[ModerationSubscriber] Unknown channel: #{channel}")

--- a/test/whispr_notifications/workers/moderation_subscriber_test.exs
+++ b/test/whispr_notifications/workers/moderation_subscriber_test.exs
@@ -69,6 +69,33 @@ defmodule WhisprNotifications.Workers.ModerationSubscriberTest do
     assert Process.alive?(pid)
   end
 
+  test "routes blocked image appeal channels without crashing" do
+    pid = Process.whereis(ModerationSubscriber)
+    assert Process.alive?(pid)
+
+    for channel <- [
+          "whispr:moderation:blocked_image_approved",
+          "whispr:moderation:blocked_image_rejected"
+        ] do
+      payload =
+        Jason.encode!(%{
+          "appealId" => "appeal-1",
+          "userId" => "user-1",
+          "conversationId" => "conv-1",
+          "messageTempId" => "temp-1",
+          "reviewerNotes" => "ok"
+        })
+
+      send(
+        pid,
+        {:redix_pubsub, nil, nil, :message, %{channel: channel, payload: payload}}
+      )
+    end
+
+    Process.sleep(100)
+    assert Process.alive?(pid)
+  end
+
   test "routes to every moderation handler (happy payloads)" do
     pid = Process.whereis(ModerationSubscriber)
 
@@ -94,8 +121,7 @@ defmodule WhisprNotifications.Workers.ModerationSubscriberTest do
     for {channel, payload} <- routed do
       send(
         pid,
-        {:redix_pubsub, nil, nil, :message,
-         %{channel: channel, payload: Jason.encode!(payload)}}
+        {:redix_pubsub, nil, nil, :message, %{channel: channel, payload: Jason.encode!(payload)}}
       )
     end
 


### PR DESCRIPTION
## Summary
- Subscribe Redis channels `whispr:moderation:blocked_image_approved` et `_rejected`
- Forward décision admin via Notifications.create vers topic `user:<id>` event `blocked_image_decision`
- Payload: {appealId, decision, messageTempId, conversationId?, reason?}

Part of feat blocked image appeal (user-service PR #102, mobile-app incoming).

## Test plan
- [ ] CI mix test + credo + format passent
- [ ] Test unitaire ajoute dans moderation_subscriber_test.exs