### PR TITLE
[WHISPR-1225] fix(cors): supprimer les défauts roadmvn.com et fail-cl…

### DIFF
--- a/lib/whispr_notifications_web/plugs/cors.ex
+++ b/lib/whispr_notifications_web/plugs/cors.ex
@@ -3,8 +3,6 @@ defmodule WhisprNotificationsWeb.Plugs.Cors do
   @moduledoc "CORS headers for cross-origin requests."
   import Plug.Conn
 
-  @allowed_origins_default "https://whispr-api.roadmvn.com,https://whispr-preprod.roadmvn.com,https://preprod-whispr-api.roadmvn.com,https://whispr.epitech.beer"
-
   def init(opts), do: opts
 
   def call(%Plug.Conn{method: "OPTIONS"} = conn, _opts) do
@@ -33,10 +31,19 @@ defmodule WhisprNotificationsWeb.Plugs.Cors do
   end
 
   defp allowed_origins do
-    (System.get_env("CORS_ALLOWED_ORIGINS") || @allowed_origins_default)
-    |> String.split(",")
-    |> Enum.map(&String.trim/1)
-    |> Enum.filter(&(&1 != ""))
+    case System.get_env("CORS_ALLOWED_ORIGINS") do
+      nil ->
+        []
+
+      "" ->
+        []
+
+      value ->
+        value
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> Enum.filter(&(&1 != ""))
+    end
   end
 end
 

--- a/test/whispr_notifications_web/plugs/cors_test.exs
+++ b/test/whispr_notifications_web/plugs/cors_test.exs
@@ -1,13 +1,28 @@
 defmodule WhisprNotificationsWeb.Plugs.CorsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Plug.Conn
   import Plug.Test
 
   alias WhisprNotificationsWeb.Plugs.Cors
 
   @opts Cors.init([])
-  @allowed_origin "https://whispr-api.roadmvn.com"
+  @env_key "CORS_ALLOWED_ORIGINS"
+  @allowed_origin "https://whispr.test.local"
   @disallowed_origin "https://evil.example.com"
+
+  setup do
+    previous = System.get_env(@env_key)
+    System.put_env(@env_key, @allowed_origin)
+
+    on_exit(fn ->
+      case previous do
+        nil -> System.delete_env(@env_key)
+        value -> System.put_env(@env_key, value)
+      end
+    end)
+
+    :ok
+  end
 
   test "adds CORS headers for allowed origin" do
     conn =
@@ -71,5 +86,51 @@ defmodule WhisprNotificationsWeb.Plugs.CorsTest do
     assert conn.status == 204
     assert conn.halted == true
     assert get_resp_header(conn, "access-control-allow-origin") == []
+  end
+
+  describe "fail-closed when CORS_ALLOWED_ORIGINS is unset" do
+    setup do
+      System.delete_env(@env_key)
+      :ok
+    end
+
+    test "no CORS headers even for an origin that would otherwise be allowed" do
+      conn =
+        :get
+        |> conn("/api/v1/health")
+        |> put_req_header("origin", @allowed_origin)
+        |> Cors.call(@opts)
+
+      assert get_resp_header(conn, "access-control-allow-origin") == []
+    end
+
+    test "OPTIONS request returns 204 and halts without CORS headers" do
+      conn =
+        :options
+        |> conn("/api/v1/health")
+        |> put_req_header("origin", @allowed_origin)
+        |> Cors.call(@opts)
+
+      assert conn.status == 204
+      assert conn.halted == true
+      assert get_resp_header(conn, "access-control-allow-origin") == []
+    end
+  end
+
+  describe "fail-closed when CORS_ALLOWED_ORIGINS is empty" do
+    setup do
+      System.put_env(@env_key, "")
+      :ok
+    end
+
+    test "no CORS headers even for an origin that would otherwise be allowed" do
+      conn =
+        :get
+        |> conn("/api/v1/health")
+        |> put_req_header("origin", @allowed_origin)
+        |> Cors.call(@opts)
+
+      assert get_resp_header(conn, "access-control-allow-origin") == []
+    end
   end
 end


### PR DESCRIPTION
…oser le plug

- Retire @allowed_origins_default qui pointait sur des domaines roadmvn.com / epitech.beer obsolètes ; allowed_origins/0 retourne maintenant [] quand CORS_ALLOWED_ORIGINS est nil ou vide.
- Aligne le comportement avec user/media/scheduling/auth-service post WHISPR-1213.
- Tests : fixture sur whispr.test.local + setter explicite via System.put_env/2, ajout de cas fail-closed (env nil + env "").

Closes WHISPR-1225