### PR TITLE
[WHISPR-1296] docs(comments): traduction FR + cleanup paraphrases

### DIFF
--- a/lib/whispr_notifications/application.ex
+++ b/lib/whispr_notifications/application.ex
@@ -11,16 +11,16 @@ defmodule WhisprNotifications.Application do
   def start(_type, _args) do
     children =
       [
-        # Ecto Repo — must start before anything that queries the DB
+        # Repo Ecto, doit demarrer avant tout ce qui requete la DB
         WhisprNotifications.Repo,
-        # PubSub — must start before the Endpoint
+        # PubSub, doit demarrer avant l'Endpoint
         {Phoenix.PubSub, name: WhisprNotifications.PubSub},
-        # JWKS cache — must start before the Endpoint so the Authenticate plug
-        # has a live GenServer to call on the very first request.
+        # cache JWKS : doit demarrer avant l'Endpoint pour que le plug
+        # Authenticate ait un GenServer pret des la 1ere requete
         {WhisprNotifications.Auth.JwksCache, jwks_cache_opts()},
-        # Phoenix HTTP endpoint — binds the HTTP port declared in config
+        # endpoint HTTP Phoenix, bind le port HTTP declare dans la config
         WhisprNotificationsWeb.Endpoint,
-        # Domain supervisors/workers
+        # superviseurs et workers du domaine
         {WhisprNotifications.Devices.CacheManager, []},
         {WhisprNotifications.Workers.TokenRefresher, []},
         {WhisprNotifications.Workers.CacheSyncWorker, []},
@@ -36,14 +36,14 @@ defmodule WhisprNotifications.Application do
     Supervisor.start_link(children, opts)
   end
 
-  # Push dispatchers (Pigeon FCM + Pigeon APNS) only start when their
-  # respective creds are present. Otherwise we let the tree boot cleanly in
-  # dev/CI and the matching client returns `{:error, :not_configured}`.
+  # les dispatchers push (Pigeon FCM + Pigeon APNS) ne demarrent que si
+  # leurs creds respectifs sont fournis. sinon on laisse l'arbre booter
+  # proprement en dev/CI et le client retourne `{:error, :not_configured}`.
   defp push_children do
     fcm_children() ++ apns_children()
   end
 
-  # Goth + Pigeon FCM dispatcher — needs FCM service account + project id.
+  # dispatcher Goth + Pigeon FCM, requiert service account FCM + project id
   @doc false
   def fcm_children do
     cfg = Application.get_env(:whispr_notification, :fcm, [])
@@ -56,12 +56,12 @@ defmodule WhisprNotifications.Application do
       ]
     else
       _ ->
-        Logger.info("[FCM] not configured — Goth + FcmDispatcher not started")
+        Logger.info("[FCM] non configure - Goth + FcmDispatcher non demarres")
         []
     end
   end
 
-  # Pigeon APNS dispatcher — needs the .p8 path + key id + team id.
+  # dispatcher Pigeon APNS, requiert chemin du .p8 + key id + team id
   @doc false
   def apns_children do
     cfg = Application.get_env(:whispr_notification, :apns, [])
@@ -69,22 +69,23 @@ defmodule WhisprNotifications.Application do
     if Keyword.get(cfg, :enabled, false) do
       [WhisprNotifications.Delivery.ApnsDispatcher]
     else
-      Logger.info("[APNS] not configured — ApnsDispatcher not started")
+      Logger.info("[APNS] non configure - ApnsDispatcher non demarre")
       []
     end
   end
 
-  # Required by Phoenix to reload configuration on config_change/3
+  # requis par Phoenix pour recharger la conf via config_change/3
   @impl true
   def config_change(changed, _new, removed) do
     WhisprNotificationsWeb.Endpoint.config_change(changed, removed)
     :ok
   end
 
-  # Build JwksCache options. We pre-fetch the JWKS once at boot so the cache
-  # starts with real keys; if the auth-service is unreachable, we fall back to
-  # an empty key set so the app still starts (the plug will just return 401
-  # until the cache is repopulated) instead of crash-looping the supervisor.
+  # construit les options du JwksCache. on prefetch les JWKS une fois au
+  # boot pour que le cache demarre avec des cles reelles. si auth-service
+  # est injoignable, on tombe sur un key set vide pour que l'app demarre
+  # quand meme (le plug renverra juste 401 jusqu'au prochain refresh) au
+  # lieu de crash-looper le superviseur.
   @doc false
   def jwks_cache_opts do
     jwt_cfg = Application.get_env(:whispr_notification, :jwt, [])
@@ -101,7 +102,7 @@ defmodule WhisprNotifications.Application do
 
       {:error, reason} ->
         Logger.warning(
-          "JWKS prefetch from #{inspect(url)} failed: #{inspect(reason)} — starting with empty key set"
+          "JWKS prefetch from #{inspect(url)} failed: #{inspect(reason)} - starting with empty key set"
         )
 
         [{:allow_empty, true}, {:jwks_url, url} | base]

--- a/lib/whispr_notifications/delivery/apns_client.ex
+++ b/lib/whispr_notifications/delivery/apns_client.ex
@@ -1,30 +1,30 @@
 defmodule WhisprNotifications.Delivery.ApnsClient do
   @moduledoc """
-  APNS push via Pigeon 2.x (HTTP/2 + JWT ES256).
+  Push APNS via Pigeon 2.x (HTTP/2 + JWT ES256).
 
-  Same callback contract as the previous stub so `BatchProcessor` and
-  `Devices.mark_invalid/2` don't need to change:
+  Meme contrat de callback que le stub precedent pour eviter d'avoir a
+  toucher `BatchProcessor` ni `Devices.mark_invalid/2` :
 
       :ok
-      | {:error, :token_invalid}     # hard failure — soft-delete the device
-      | {:error, :transient}         # retryable (network, 5xx, quota, auth)
-      | {:error, :not_configured}    # APNS creds absent in this env (dev/CI)
+      | {:error, :token_invalid}     # echec definitif, soft-delete le device
+      | {:error, :transient}         # retryable (reseau, 5xx, quota, auth)
+      | {:error, :not_configured}    # creds APNS absents (dev/CI)
 
-  Response atoms from `Pigeon.APNS` are mapped as follows:
+  Mapping des atomes de reponse de `Pigeon.APNS` :
 
-    * `:success`                                          → `:ok`
+    * `:success`                                          -> `:ok`
     * `:bad_device_token`, `:unregistered`,
       `:device_token_not_for_topic`, `:missing_device_token`,
       `:expired_token`, `:bad_topic`, `:topic_disallowed`,
-      `:invalid_push_type`                                → `{:error, :token_invalid}`
+      `:invalid_push_type`                                -> `{:error, :token_invalid}`
     * `:internal_server_error`, `:service_unavailable`,
       `:too_many_requests`, `:too_many_provider_token_updates`,
       `:expired_provider_token`, `:invalid_provider_token`,
       `:missing_provider_token`, `:idle_timeout`,
-      `:shutdown`, `:unknown_error`, `:timeout`           → `{:error, :transient}`
+      `:shutdown`, `:unknown_error`, `:timeout`           -> `{:error, :transient}`
 
-  Everything unknown degrades to `:transient` so we never drop a valid token
-  on an error we didn't anticipate.
+  Tout le reste retombe sur `:transient` pour eviter de perdre un token
+  valide sur une erreur qu'on n'avait pas prevue.
   """
 
   alias Pigeon.APNS.Notification, as: APNSNotification
@@ -64,9 +64,10 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
   def send(_device, _payload), do: {:error, :token_invalid}
 
   @doc """
-  Builds a `Pigeon.APNS.Notification` from the internal payload shape used by
-  `BatchProcessor` + `Formatter.to_platform_payload/3`. Public so it can be
-  unit-tested without standing up a dispatcher.
+  Construit une `Pigeon.APNS.Notification` a partir de la shape payload
+  interne utilisee par `BatchProcessor` +
+  `Formatter.to_platform_payload/3`. Public pour pouvoir etre teste
+  sans avoir a demarrer un dispatcher.
   """
   @spec build_notification(DeviceCache.device(), map()) :: APNSNotification.t()
   def build_notification(%{token: token} = device, payload) do
@@ -81,8 +82,8 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
   end
 
   @doc """
-  Pure mapping from a Pigeon APNS response atom back to the internal
-  `ApnsClient` contract. Public for unit-testing.
+  Mapping pur d'un atome de reponse Pigeon APNS vers le contrat interne
+  `ApnsClient`. Public pour les tests unitaires.
   """
   @spec response_to_result(APNSNotification.t()) ::
           :ok | {:error, :token_invalid | :transient}
@@ -98,7 +99,7 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
     {:error, :transient}
   end
 
-  # ----- private ---------------------------------------------------------
+  # ----- prive ----------------------------------------------------------
 
   defp apns_enabled? do
     :whispr_notification
@@ -136,8 +137,9 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
     :exit, _ -> {:error, :not_configured}
   end
 
-  # APNS topic = app bundle id. Falls back to a configured default if the
-  # device row didn't carry one (older inserts before the column existed).
+  # le topic APNS = le bundle id de l'app. fallback sur un default
+  # configure si le device en DB n'en porte pas (anciens inserts avant
+  # l'ajout de la colonne).
   defp topic_for(%{app: app}) when is_binary(app) and app != "", do: app
 
   defp topic_for(_device) do
@@ -146,9 +148,9 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
     |> Keyword.get(:default_topic)
   end
 
-  # Accepts both the `Formatter.to_platform_payload/3` shape (already
-  # `%{"aps" => %{...}, "meta" => %{...}}`) and a flat `%{title, body}`
-  # convenience shape used by some callers/tests.
+  # accepte la shape `Formatter.to_platform_payload/3` (deja
+  # `%{"aps" => %{...}, "meta" => %{...}}`) et une shape plate
+  # `%{title, body}` utilisee par certains callers/tests.
   defp normalise_payload(%{"aps" => _} = payload), do: payload
 
   defp normalise_payload(%{title: title, body: body} = payload) do

--- a/lib/whispr_notifications/delivery/apns_dispatcher.ex
+++ b/lib/whispr_notifications/delivery/apns_dispatcher.ex
@@ -1,11 +1,13 @@
 defmodule WhisprNotifications.Delivery.ApnsDispatcher do
   @moduledoc """
-  Pigeon dispatcher for Apple Push Notification Service (APNS HTTP/2 + JWT ES256).
+  Dispatcher Pigeon pour Apple Push Notification Service
+  (APNS HTTP/2 + JWT ES256).
 
-  Configured at boot by `config/runtime.exs` from `APNS_KEY_PATH`,
-  `APNS_KEY_ID`, `APNS_TEAM_ID` and `APNS_MODE`. Only added to the
-  supervision tree by `WhisprNotifications.Application` when APNS is fully
-  configured. Otherwise `ApnsClient.send/2` returns `{:error, :not_configured}`.
+  Configure au boot par `config/runtime.exs` via `APNS_KEY_PATH`,
+  `APNS_KEY_ID`, `APNS_TEAM_ID` et `APNS_MODE`. Ajoute a l'arbre de
+  supervision par `WhisprNotifications.Application` uniquement quand
+  APNS est entierement configure. Sinon `ApnsClient.send/2` renvoie
+  `{:error, :not_configured}`.
   """
 
   use Pigeon.Dispatcher, otp_app: :whispr_notification


### PR DESCRIPTION
## Summary
- Traduit en francais les commentaires anglais dans application.ex, apns_dispatcher.ex et apns_client.ex
- Em-dash remplaces par des tirets simples
- Aucune modification de code (logique inchangee)

## Test plan
- [x] mix test green (478/478)
- [x] mix format --check-formatted clean
- [x] mix credo --strict baseline preserve

Closes WHISPR-1296