### PR TITLE
[WHISPR-989] feat(security): valider SECRET_KEY_BASE >= 64 bytes en prod

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -92,7 +92,10 @@ if config_env() == :prod do
       ip: {0, 0, 0, 0},
       port: String.to_integer(System.get_env("PORT", "4011"))
     ],
-    secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
+    secret_key_base:
+      WhisprNotifications.RuntimeSecret.validate_secret_key_base!(
+        System.fetch_env!("SECRET_KEY_BASE")
+      ),
     url: [
       host: System.get_env("PHX_HOST", "localhost"),
       port: 443,

--- a/lib/whispr_notifications/runtime_secret.ex
+++ b/lib/whispr_notifications/runtime_secret.ex
@@ -1,0 +1,35 @@
+defmodule WhisprNotifications.RuntimeSecret do
+  @moduledoc """
+  Garde-fous pour les secrets lus au démarrage du release dans `runtime.exs`.
+
+  Phoenix utilise `secret_key_base` pour signer/chiffrer les cookies de session
+  et les tokens. Une valeur trop courte affaiblit ces garanties — `mix phx.gen.secret`
+  produit 64 octets et c'est le minimum recommandé en prod.
+  """
+
+  @minimum_secret_key_base_bytes 64
+
+  @doc """
+  Vérifie qu'une valeur de `SECRET_KEY_BASE` est utilisable en prod.
+
+  Renvoie la valeur telle quelle si elle est conforme, raise sinon.
+  Ne pas appeler en `:dev` ou `:test` : on tolère un secret court pour ne pas
+  ralentir le boot local.
+  """
+  @spec validate_secret_key_base!(String.t()) :: String.t()
+  def validate_secret_key_base!(value) when is_binary(value) do
+    if byte_size(value) < @minimum_secret_key_base_bytes do
+      raise """
+      SECRET_KEY_BASE must be at least #{@minimum_secret_key_base_bytes} bytes \
+      (currently #{byte_size(value)}).
+      Generate one with: mix phx.gen.secret
+      """
+    end
+
+    value
+  end
+
+  @doc "Longueur minimale exigée en bytes pour `SECRET_KEY_BASE` en prod."
+  @spec minimum_secret_key_base_bytes() :: pos_integer()
+  def minimum_secret_key_base_bytes, do: @minimum_secret_key_base_bytes
+end

--- a/test/whispr_notifications/runtime_secret_test.exs
+++ b/test/whispr_notifications/runtime_secret_test.exs
@@ -1,0 +1,45 @@
+defmodule WhisprNotifications.RuntimeSecretTest do
+  use ExUnit.Case, async: true
+
+  alias WhisprNotifications.RuntimeSecret
+
+  describe "validate_secret_key_base!/1" do
+    test "accepts a 64-byte secret and returns it unchanged" do
+      secret = String.duplicate("a", 64)
+      assert RuntimeSecret.validate_secret_key_base!(secret) == secret
+    end
+
+    test "accepts a longer secret (mix phx.gen.secret produces 64+)" do
+      secret = String.duplicate("z", 96)
+      assert RuntimeSecret.validate_secret_key_base!(secret) == secret
+    end
+
+    test "raises when the secret is shorter than the minimum" do
+      short = String.duplicate("a", 63)
+
+      assert_raise RuntimeError, ~r/SECRET_KEY_BASE must be at least 64 bytes/, fn ->
+        RuntimeSecret.validate_secret_key_base!(short)
+      end
+    end
+
+    test "raises with the actual byte size in the error message" do
+      short = "too-short"
+
+      assert_raise RuntimeError, ~r/currently #{byte_size(short)}/, fn ->
+        RuntimeSecret.validate_secret_key_base!(short)
+      end
+    end
+
+    test "raises on empty string" do
+      assert_raise RuntimeError, ~r/currently 0/, fn ->
+        RuntimeSecret.validate_secret_key_base!("")
+      end
+    end
+  end
+
+  describe "minimum_secret_key_base_bytes/0" do
+    test "is 64 bytes (matches mix phx.gen.secret default output)" do
+      assert RuntimeSecret.minimum_secret_key_base_bytes() == 64
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Ajoute `WhisprNotifications.RuntimeSecret.validate_secret_key_base!/1` qui raise au boot si la valeur fait moins de 64 bytes (longueur produite par `mix phx.gen.secret`).
- Branche la validation dans `config/runtime.exs` uniquement quand `config_env() == :prod` - dev/test gardent leur tolerance pour ne pas ralentir le boot local.
- Couvre la validation par un test unitaire dedie sans toucher la DB.

Sub-tasks 1 et 2 du ticket (routes settings/mute derriere `:jwt_authenticated`, JwksCache dans la supervision tree) sont deja en place sur `main`.

Sub-task 4 (renforcement test moderation_subscriber) est skip : la suite couvre deja le routage avec assertions sur les broadcasts (cf `test "broadcasts blocked_image_decision to user topic on approved channel"` et son pendant rejected).

## Test plan

- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` (3 issues preexistantes, aucune introduite)
- [x] `mix test` 484 tests, 0 failures
- [x] Verifie qu'un secret < 64 bytes raise avec un message lisible

Closes WHISPR-989