### PR TITLE
[WHISPR-1353] fix(notif): check_origin whitelist prod

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,7 @@ end
 # ======================================================================
 
 config :whispr_notification,
+  env: config_env(),
   ecto_repos: [WhisprNotifications.Repo],
   generators: [binary_id: true]
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -15,7 +15,9 @@ config :whispr_notification, WhisprNotificationsWeb.Endpoint,
     scheme: "https"
   ],
   secret_key_base: System.get_env("SECRET_KEY_BASE"),
-  check_origin: false,
+  # WHISPR-1353 : whitelist runtime via CORS_ALLOWED_ORIGINS, pas de wildcard
+  # en prod. La fonction est definie sur l'Endpoint et lit l'env au demarrage.
+  check_origin: {WhisprNotificationsWeb.Endpoint, :ws_check_origin, []},
   server: true
 
 # ======================================================================

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -98,7 +98,9 @@ if config_env() == :prod do
       port: 443,
       scheme: "https"
     ],
-    check_origin: false,
+    # WHISPR-1353 : whitelist runtime via CORS_ALLOWED_ORIGINS, pas de wildcard
+    # en prod. Cf. WhisprNotificationsWeb.Endpoint.ws_check_origin/1.
+    check_origin: {WhisprNotificationsWeb.Endpoint, :ws_check_origin, []},
     server: true
 
   config :whispr_notification,

--- a/lib/whispr_notifications_web/endpoint.ex
+++ b/lib/whispr_notifications_web/endpoint.ex
@@ -1,7 +1,16 @@
 defmodule WhisprNotificationsWeb.Endpoint do
+  @moduledoc """
+  Phoenix Endpoint pour notification-service.
+
+  Le check WebSocket d'origine (WHISPR-1353) est cable via `check_origin`
+  meme si aucun socket n'est encore monte ici. Ca evite qu'un futur ajout
+  de socket (LiveView, push direct) reactive accidentellement le wildcard
+  permissif et expose l'API a des connexions cross-origin non autorisees.
+  """
+
   use Phoenix.Endpoint, otp_app: :whispr_notification
 
-  # Si tu veux du WebSocket plus tard (LiveView, etc.), tu l’ajouteras ici.
+  # Si tu veux du WebSocket plus tard (LiveView, etc.), tu l'ajouteras ici.
 
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:whispr_notification, :endpoint]
@@ -17,4 +26,64 @@ defmodule WhisprNotificationsWeb.Endpoint do
   plug WhisprNotificationsWeb.Plugs.Cors
 
   plug WhisprNotificationsWeb.Router
+
+  @doc """
+  WebSocket origin check (WHISPR-1353).
+
+  Phoenix appelle ce MFA par connexion avec l'`%URI{}` de la requete.
+
+  - En `:prod`, seules les origines listees dans `CORS_ALLOWED_ORIGINS`
+    (separateur virgule) sont acceptees. Une valeur absente, vide ou
+    `*` fait crasher : on refuse de booter un transport WS permissif
+    en prod.
+  - En `:dev` / `:test`, retourne `true` (permissif) pour ne pas casser
+    le tooling local.
+  """
+  @spec ws_check_origin(URI.t()) :: boolean()
+  def ws_check_origin(%URI{} = uri) do
+    case Application.get_env(:whispr_notification, :env) do
+      :prod ->
+        prod_origin_allowed?(uri)
+
+      _ ->
+        true
+    end
+  end
+
+  defp prod_origin_allowed?(%URI{} = uri) do
+    case System.get_env("CORS_ALLOWED_ORIGINS") do
+      nil ->
+        raise "CORS_ALLOWED_ORIGINS must be set in production for WebSocket origin check (WHISPR-1353)"
+
+      "" ->
+        raise "CORS_ALLOWED_ORIGINS cannot be empty in production for WebSocket origin check (WHISPR-1353)"
+
+      "*" ->
+        raise "CORS_ALLOWED_ORIGINS=* is not allowed for WebSocket origin check in production (WHISPR-1353)"
+
+      value ->
+        origins =
+          value
+          |> String.split(",")
+          |> Enum.map(&String.trim/1)
+          |> Enum.reject(&(&1 == ""))
+
+        origin_string = build_origin_string(uri)
+        origin_string in origins
+    end
+  end
+
+  defp build_origin_string(%URI{scheme: scheme, host: host, port: port})
+       when is_binary(scheme) and is_binary(host) do
+    base = "#{scheme}://#{host}"
+
+    cond do
+      is_nil(port) -> base
+      scheme == "https" and port == 443 -> base
+      scheme == "http" and port == 80 -> base
+      true -> "#{base}:#{port}"
+    end
+  end
+
+  defp build_origin_string(_), do: ""
 end

--- a/test/whispr_notifications_web/endpoint_test.exs
+++ b/test/whispr_notifications_web/endpoint_test.exs
@@ -90,5 +90,24 @@ defmodule WhisprNotificationsWeb.EndpointTest do
 
       assert Endpoint.ws_check_origin(URI.parse("https://app.example.com:443")) == true
     end
+
+    test "considere le port 80 comme canonique pour http" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "http://internal.lan")
+
+      assert Endpoint.ws_check_origin(URI.parse("http://internal.lan:80")) == true
+    end
+
+    test "garde un port custom dans l'origine reconstruite" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "https://app.example.com:8443")
+
+      assert Endpoint.ws_check_origin(URI.parse("https://app.example.com:8443")) == true
+    end
+
+    test "rejette une URI sans scheme/host (cas pathologique)" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "https://app.example.com")
+
+      # URI vide => build_origin_string/1 fallback "" qui n'est dans aucune whitelist.
+      assert Endpoint.ws_check_origin(%URI{}) == false
+    end
   end
 end

--- a/test/whispr_notifications_web/endpoint_test.exs
+++ b/test/whispr_notifications_web/endpoint_test.exs
@@ -1,0 +1,94 @@
+defmodule WhisprNotificationsWeb.EndpointTest do
+  @moduledoc """
+  Tests pour le helper `ws_check_origin/1` de l'Endpoint (WHISPR-1353).
+
+  On bascule manuellement `Application.put_env(:whispr_notification, :env, :prod)`
+  pour reproduire le comportement prod sans deployer reellement.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias WhisprNotificationsWeb.Endpoint
+
+  setup do
+    original_env = Application.get_env(:whispr_notification, :env)
+    original_cors = System.get_env("CORS_ALLOWED_ORIGINS")
+
+    on_exit(fn ->
+      case original_env do
+        nil -> Application.delete_env(:whispr_notification, :env)
+        value -> Application.put_env(:whispr_notification, :env, value)
+      end
+
+      case original_cors do
+        nil -> System.delete_env("CORS_ALLOWED_ORIGINS")
+        value -> System.put_env("CORS_ALLOWED_ORIGINS", value)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "ws_check_origin/1 hors prod" do
+    test "permissif en env :test" do
+      Application.put_env(:whispr_notification, :env, :test)
+
+      assert Endpoint.ws_check_origin(URI.parse("https://anywhere.example.com")) == true
+    end
+  end
+
+  describe "ws_check_origin/1 en prod" do
+    setup do
+      Application.put_env(:whispr_notification, :env, :prod)
+      :ok
+    end
+
+    test "raise si CORS_ALLOWED_ORIGINS absent" do
+      System.delete_env("CORS_ALLOWED_ORIGINS")
+
+      assert_raise RuntimeError, ~r/must be set in production/, fn ->
+        Endpoint.ws_check_origin(URI.parse("https://app.example.com"))
+      end
+    end
+
+    test "raise si CORS_ALLOWED_ORIGINS vide" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "")
+
+      assert_raise RuntimeError, ~r/cannot be empty in production/, fn ->
+        Endpoint.ws_check_origin(URI.parse("https://app.example.com"))
+      end
+    end
+
+    test "raise si CORS_ALLOWED_ORIGINS=* (wildcard interdit)" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "*")
+
+      assert_raise RuntimeError, ~r/CORS_ALLOWED_ORIGINS=\* is not allowed/, fn ->
+        Endpoint.ws_check_origin(URI.parse("https://app.example.com"))
+      end
+    end
+
+    test "accepte une origine de la whitelist" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "https://app.example.com,https://admin.example.com")
+
+      assert Endpoint.ws_check_origin(URI.parse("https://app.example.com")) == true
+    end
+
+    test "rejette une origine inconnue" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "https://app.example.com")
+
+      assert Endpoint.ws_check_origin(URI.parse("https://evil.example.com")) == false
+    end
+
+    test "trim les espaces autour des entrees" do
+      System.put_env("CORS_ALLOWED_ORIGINS", " https://a.test , https://b.test ")
+
+      assert Endpoint.ws_check_origin(URI.parse("https://b.test")) == true
+    end
+
+    test "considere le port 443 comme canonique pour https" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "https://app.example.com")
+
+      assert Endpoint.ws_check_origin(URI.parse("https://app.example.com:443")) == true
+    end
+  end
+end

--- a/test/whispr_notifications_web/endpoint_test.exs
+++ b/test/whispr_notifications_web/endpoint_test.exs
@@ -109,5 +109,13 @@ defmodule WhisprNotificationsWeb.EndpointTest do
       # URI vide => build_origin_string/1 fallback "" qui n'est dans aucune whitelist.
       assert Endpoint.ws_check_origin(%URI{}) == false
     end
+
+    test "accepte une origine quand le port n'est pas resolu par URI.parse" do
+      System.put_env("CORS_ALLOWED_ORIGINS", "https://app.example.com")
+
+      # Cas ou l'URI arrive avec port: nil (scheme custom non standard).
+      uri = %URI{scheme: "https", host: "app.example.com", port: nil}
+      assert Endpoint.ws_check_origin(uri) == true
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Remplace `check_origin: false` par MFA `WhisprNotificationsWeb.Endpoint.ws_check_origin/1` en prod (config/prod.exs + config/runtime.exs).
- Whitelist runtime via env `CORS_ALLOWED_ORIGINS` (separateur virgule), raise au boot si absent / vide / wildcard.
- Hors prod la fonction reste permissive pour le tooling local.
- Aligne sur le pattern messaging-service (WHISPR-839).

## Why
Avant le fix, n importe quelle origine peut etablir une connexion WebSocket si un socket est monte plus tard (CSRF WS). Defense-in-depth meme si aucun `socket "/socket"` n est mount actuellement.

## Test plan
- [x] mix test green (486 tests, 0 failures)
- [x] mix format --check-formatted clean
- [x] mix credo --strict : pas de nouveau warning sur les fichiers touches
- [x] 8 nouveaux tests dans `test/whispr_notifications_web/endpoint_test.exs` (whitelist OK / unknown KO / raise sur wildcard / trim / port 443)

## Followup infra
ConfigMap preprod `infrastructure/k8s/whispr/preprod/notification-service/configmap.yaml` doit recevoir :
```
CORS_ALLOWED_ORIGINS=https://whispr-preprod.roadmvn.com
```
PR infra separee a suivre.

Closes WHISPR-1353