### PR TITLE
[WHISPR-1361] fix(notif): cache_manager non-blocking handle_call

### DIFF
--- a/lib/whispr_notifications/devices/cache_manager.ex
+++ b/lib/whispr_notifications/devices/cache_manager.ex
@@ -1,14 +1,52 @@
 defmodule WhisprNotifications.Devices.CacheManager do
   @moduledoc """
-  GenServer qui maintient un cache en mémoire des devices des utilisateurs.
-  Il utilise AuthClient pour synchroniser.
+  GenServer qui maintient un cache en memoire des devices des utilisateurs.
+
+  ## Pourquoi le pattern async
+
+  Sur cache miss, le fetch (Ecto + parfois HTTP via AuthClient) prenait plusieurs
+  centaines de ms a quelques secondes. Comme le GenServer est un singleton
+  nomme, tous les `get_cache/1` etaient serialises dans la mailbox. Sur une
+  rafale (50 messages dans un groupe = 50 lookups), cela cascadait en timeouts
+  (default 5s) et bloquait toute la livraison de notifs.
+
+  Solution : on repond toujours `{:noreply, state}` immediatement au caller
+  via `from`, on lance le fetch dans un `Task.Supervisor` (un Task par user_id),
+  et c'est le `handle_info` qui repond avec `GenServer.reply(from, result)`
+  quand le fetch finit. La mailbox reste libre pour traiter les autres
+  `get_cache/1` en parallele.
+
+  On coalesce aussi les requetes concurrentes pour le meme user_id (single-flight) :
+  si deux callers demandent le cache du meme user pendant un fetch, le 2eme
+  attend la reponse du fetch en cours au lieu d'en lancer un nouveau.
   """
 
   use GenServer
 
   alias WhisprNotifications.Devices.{AuthClient, DeviceCache}
 
-  @type state :: %{String.t() => DeviceCache.t()}
+  # default timeout cote caller : volontairement plus court que le 5s default
+  # de GenServer.call pour que les call sites coupent court avant que la
+  # mailbox du caller (BatchProcessor, etc.) ne sature.
+  @default_get_timeout 3_000
+
+  # client par defaut. Configurable via :whispr_notification, :devices_auth_client
+  # pour permettre l'injection de fakes en test (cf. cache_manager_test.exs).
+  @default_auth_client AuthClient
+
+  # nom du Task.Supervisor qui isole les fetchs : un crash de fetch n'impacte
+  # pas le CacheManager (async_nolink) ni les autres fetchs (one_for_one).
+  @task_supervisor WhisprNotifications.Devices.CacheManager.TaskSupervisor
+
+  @type state :: %{
+          caches: %{String.t() => DeviceCache.t()},
+          # user_id => {task_ref, [from1, from2, ...]} : les callers en attente
+          # du fetch en cours pour ce user_id. Permet de coalesce les requetes.
+          inflight: %{String.t() => {reference(), [GenServer.from()]}},
+          # task_ref => user_id : index inverse pour retrouver le user_id
+          # quand un Task termine (DOWN ou {ref, result}).
+          ref_to_user: %{reference() => String.t()}
+        }
 
   ## Public API
 
@@ -16,9 +54,22 @@ defmodule WhisprNotifications.Devices.CacheManager do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
-  @spec get_cache(String.t()) :: {:ok, DeviceCache.t()} | {:error, term()}
-  def get_cache(user_id) do
-    GenServer.call(__MODULE__, {:get_cache, user_id})
+  @doc """
+  Recupere le cache devices d'un utilisateur. Sur cache miss, lance un
+  fetch async et bloque le caller jusqu'a `timeout` ms.
+
+  Le timeout par defaut (#{@default_get_timeout} ms) est plus court que le
+  default de `GenServer.call` (5_000 ms) pour eviter qu'un caller bloque
+  trop longtemps en cas de DB lente.
+  """
+  @spec get_cache(String.t(), timeout()) :: {:ok, DeviceCache.t()} | {:error, term()}
+  def get_cache(user_id, timeout \\ @default_get_timeout) do
+    GenServer.call(__MODULE__, {:get_cache, user_id}, timeout)
+  catch
+    # GenServer.call leve un :exit en cas de timeout. on le traduit en
+    # {:error, :timeout} pour que les call sites n'aient pas a se proteger
+    # avec un try/catch.
+    :exit, {:timeout, _} -> {:error, :timeout}
   end
 
   @spec refresh_cache(String.t()) :: :ok
@@ -29,33 +80,120 @@ defmodule WhisprNotifications.Devices.CacheManager do
   ## Callbacks
 
   @impl true
-  def init(state), do: {:ok, state}
+  def init(_state) do
+    # on demarre le Task.Supervisor sous le meme arbre. start_link de
+    # Task.Supervisor en init/1 est sur, on est encore dans le boot du
+    # CacheManager donc personne ne nous appelle encore.
+    {:ok, _} = Task.Supervisor.start_link(name: @task_supervisor)
+
+    {:ok, %{caches: %{}, inflight: %{}, ref_to_user: %{}}}
+  end
 
   @impl true
-  def handle_call({:get_cache, user_id}, _from, state) do
-    case Map.fetch(state, user_id) do
+  def handle_call({:get_cache, user_id}, from, state) do
+    case Map.fetch(state.caches, user_id) do
       {:ok, cache} ->
+        # cache hit : reply sync, pas de fetch.
         {:reply, {:ok, cache}, state}
 
       :error ->
-        case AuthClient.fetch_devices(user_id) do
-          {:ok, cache} ->
-            {:reply, {:ok, cache}, Map.put(state, user_id, cache)}
-
-          error ->
-            {:reply, error, state}
-        end
+        # cache miss : on enregistre le caller comme waiter et on lance
+        # (ou on rejoint) un fetch async. {:noreply, state} libere la
+        # mailbox pour traiter les autres get_cache pendant le fetch.
+        {:noreply, enqueue_waiter(state, user_id, from)}
     end
   end
 
   @impl true
   def handle_cast({:refresh_cache, user_id}, state) do
+    # refresh est fire-and-forget : pas de waiters, on ecrit le resultat
+    # dans le cache uniquement si le fetch reussit.
     new_state =
-      case AuthClient.fetch_devices(user_id) do
-        {:ok, cache} -> Map.put(state, user_id, cache)
+      case auth_client().fetch_devices(user_id) do
+        {:ok, cache} -> put_in(state, [:caches, user_id], cache)
         _ -> state
       end
 
     {:noreply, new_state}
+  end
+
+  # Reception du resultat d'un Task lance par enqueue_waiter/3.
+  @impl true
+  def handle_info({ref, result}, state) when is_reference(ref) do
+    case Map.pop(state.ref_to_user, ref) do
+      {nil, _} ->
+        # ref inconnue (Task lance avant un crash, ou monitor deja consomme).
+        {:noreply, state}
+
+      {user_id, ref_to_user} ->
+        # on a recu le resultat avant le DOWN : on demonitor pour eviter
+        # de recevoir le DOWN apres coup et de re-traiter le user_id.
+        Process.demonitor(ref, [:flush])
+
+        {_ref, waiters} = Map.fetch!(state.inflight, user_id)
+        Enum.each(waiters, &GenServer.reply(&1, result))
+
+        new_caches =
+          case result do
+            {:ok, cache} -> Map.put(state.caches, user_id, cache)
+            _ -> state.caches
+          end
+
+        {:noreply,
+         %{
+           state
+           | caches: new_caches,
+             inflight: Map.delete(state.inflight, user_id),
+             ref_to_user: ref_to_user
+         }}
+    end
+  end
+
+  # Le Task a crashe (raise non rescue, exit). async_nolink garantit qu'on
+  # ne meurt pas avec lui. On repond {:error, :fetch_crashed} aux waiters.
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) when is_reference(ref) do
+    case Map.pop(state.ref_to_user, ref) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {user_id, ref_to_user} ->
+        {_ref, waiters} = Map.fetch!(state.inflight, user_id)
+        Enum.each(waiters, &GenServer.reply(&1, {:error, {:fetch_crashed, reason}}))
+
+        {:noreply,
+         %{
+           state
+           | inflight: Map.delete(state.inflight, user_id),
+             ref_to_user: ref_to_user
+         }}
+    end
+  end
+
+  ## Internals
+
+  # Ajoute un caller a la liste des waiters pour ce user_id, en lancant
+  # un Task de fetch si aucun n'est encore en cours (single-flight).
+  defp enqueue_waiter(state, user_id, from) do
+    case Map.fetch(state.inflight, user_id) do
+      {:ok, {ref, waiters}} ->
+        # un fetch est deja en cours : on rejoint la file d'attente.
+        put_in(state.inflight[user_id], {ref, [from | waiters]})
+
+      :error ->
+        # aucun fetch en cours : on en lance un.
+        task =
+          Task.Supervisor.async_nolink(@task_supervisor, auth_client(), :fetch_devices, [user_id])
+
+        %{
+          state
+          | inflight: Map.put(state.inflight, user_id, {task.ref, [from]}),
+            ref_to_user: Map.put(state.ref_to_user, task.ref, user_id)
+        }
+    end
+  end
+
+  defp auth_client do
+    Application.get_env(:whispr_notification, :devices_auth_client, @default_auth_client)
   end
 end

--- a/lib/whispr_notifications/devices/cache_manager.ex
+++ b/lib/whispr_notifications/devices/cache_manager.ex
@@ -121,8 +121,8 @@ defmodule WhisprNotifications.Devices.CacheManager do
   @impl true
   def handle_info({ref, result}, state) when is_reference(ref) do
     case Map.pop(state.ref_to_user, ref) do
+      # coveralls-ignore-next-line - ref inconnue, branche defensive
       {nil, _} ->
-        # ref inconnue (Task lance avant un crash, ou monitor deja consomme).
         {:noreply, state}
 
       {user_id, ref_to_user} ->
@@ -154,6 +154,7 @@ defmodule WhisprNotifications.Devices.CacheManager do
   @impl true
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) when is_reference(ref) do
     case Map.pop(state.ref_to_user, ref) do
+      # coveralls-ignore-next-line - DOWN apres demonitor:flush, branche defensive
       {nil, _} ->
         {:noreply, state}
 

--- a/test/whispr_notifications/devices/cache_manager_test.exs
+++ b/test/whispr_notifications/devices/cache_manager_test.exs
@@ -102,6 +102,39 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
     end
   end
 
+  describe "fetch crash handling" do
+    setup do
+      # client qui crash : on simule un raise qui ferait exploser un Task
+      # async_nolink. Le CacheManager doit survivre et repondre a tous les
+      # waiters avec {:error, {:fetch_crashed, _}}.
+      previous = Application.get_env(:whispr_notification, :devices_auth_client)
+
+      Application.put_env(
+        :whispr_notification,
+        :devices_auth_client,
+        WhisprNotifications.Devices.CacheManagerTest.CrashingAuthClient
+      )
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:whispr_notification, :devices_auth_client, previous),
+          else: Application.delete_env(:whispr_notification, :devices_auth_client)
+      end)
+
+      :ok
+    end
+
+    test "fetch crash returns {:error, {:fetch_crashed, _}} and CacheManager survives" do
+      # CrashingAuthClient raise volontairement. Avec async_nolink, le
+      # CacheManager n'est pas tue. Les waiters sont notifies via le DOWN.
+      assert {:error, {:fetch_crashed, _reason}} =
+               CacheManager.get_cache("crash-user", 5_000)
+
+      # le GenServer principal doit toujours etre vivant.
+      assert Process.alive?(Process.whereis(CacheManager))
+    end
+  end
+
   describe "timeout handling" do
     setup do
       # client qui dort 5s : aucun get_cache(_, 200ms) ne peut reussir a temps.
@@ -167,5 +200,15 @@ defmodule WhisprNotifications.Devices.CacheManagerTest.HangingAuthClient do
   def fetch_devices(user_id) do
     Process.sleep(5_000)
     {:ok, %DeviceCache{user_id: user_id, devices: []}}
+  end
+end
+
+defmodule WhisprNotifications.Devices.CacheManagerTest.CrashingAuthClient do
+  @moduledoc false
+  @behaviour WhisprNotifications.Devices.AuthClient
+
+  @impl true
+  def fetch_devices(_user_id) do
+    raise "simulated crash"
   end
 end

--- a/test/whispr_notifications/devices/cache_manager_test.exs
+++ b/test/whispr_notifications/devices/cache_manager_test.exs
@@ -5,6 +5,7 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
   use WhisprNotifications.DataCase, async: false
 
   alias WhisprNotifications.Devices.{CacheManager, DeviceCache}
+  alias WhisprNotifications.Devices.CacheManagerTest.{HangingAuthClient, SlowAuthClient}
 
   describe "get_cache/1" do
     test "lazily fetches a user's cache via AuthClient when absent" do
@@ -18,6 +19,16 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
 
       assert first == second
     end
+
+    test "cache hit returns in well under 10ms (no fetch)" do
+      # warm up : premier appel chauffe le cache.
+      {:ok, _} = CacheManager.get_cache("cm-user-fast")
+
+      {micros, {:ok, _}} =
+        :timer.tc(fn -> CacheManager.get_cache("cm-user-fast") end)
+
+      assert micros < 10_000, "cache hit took #{micros}us, expected < 10ms"
+    end
   end
 
   describe "refresh_cache/1" do
@@ -27,5 +38,134 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
       assert {:ok, %DeviceCache{user_id: "cm-user-3"}} =
                CacheManager.get_cache("cm-user-3")
     end
+  end
+
+  describe "concurrency (WHISPR-1361)" do
+    setup do
+      # remplace le client par un fake qui dort 100ms par fetch. Si la mailbox
+      # serialisait les get_cache, 50 calls prendraient au moins 5s. Avec le
+      # pattern async_nolink, ils tournent en parallele dans le Task.Supervisor
+      # et le total reste sous la seconde.
+      previous = Application.get_env(:whispr_notification, :devices_auth_client)
+
+      Application.put_env(:whispr_notification, :devices_auth_client, SlowAuthClient)
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:whispr_notification, :devices_auth_client, previous),
+          else: Application.delete_env(:whispr_notification, :devices_auth_client)
+      end)
+
+      :ok
+    end
+
+    test "50 concurrent get_cache for distinct user_ids do not serialize" do
+      user_ids = for n <- 1..50, do: "concurrent-user-#{n}"
+
+      {micros, results} =
+        :timer.tc(fn ->
+          user_ids
+          |> Enum.map(fn uid ->
+            Task.async(fn -> CacheManager.get_cache(uid, 5_000) end)
+          end)
+          |> Enum.map(&Task.await(&1, 5_000))
+        end)
+
+      # tous les fetchs doivent avoir reussi.
+      assert Enum.all?(results, fn
+               {:ok, %DeviceCache{}} -> true
+               _ -> false
+             end)
+
+      # 50 fetchs * 100ms en sequentiel = 5_000ms. En parallele on s'attend
+      # a moins de 1s (typiquement 100-200ms). On laisse 1s de marge pour
+      # tolerer la CI lente.
+      assert micros < 1_000_000,
+             "50 parallel fetchs took #{div(micros, 1000)}ms, expected < 1000ms"
+    end
+
+    test "concurrent get_cache for same user_id are coalesced (single fetch)" do
+      # reset compteur du fake
+      SlowAuthClient.reset_count()
+
+      tasks =
+        for _ <- 1..10 do
+          Task.async(fn -> CacheManager.get_cache("coalesce-user", 5_000) end)
+        end
+
+      results = Enum.map(tasks, &Task.await(&1, 5_000))
+
+      assert Enum.all?(results, &match?({:ok, %DeviceCache{user_id: "coalesce-user"}}, &1))
+
+      # single-flight : un seul fetch reel meme avec 10 callers concurrents.
+      assert SlowAuthClient.get_count() == 1
+    end
+  end
+
+  describe "timeout handling" do
+    setup do
+      # client qui dort 5s : aucun get_cache(_, 200ms) ne peut reussir a temps.
+      previous = Application.get_env(:whispr_notification, :devices_auth_client)
+
+      Application.put_env(:whispr_notification, :devices_auth_client, HangingAuthClient)
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:whispr_notification, :devices_auth_client, previous),
+          else: Application.delete_env(:whispr_notification, :devices_auth_client)
+      end)
+
+      :ok
+    end
+
+    test "get_cache with explicit short timeout returns {:error, :timeout}" do
+      assert {:error, :timeout} = CacheManager.get_cache("hang-user", 200)
+    end
+  end
+end
+
+defmodule WhisprNotifications.Devices.CacheManagerTest.SlowAuthClient do
+  @moduledoc false
+  alias WhisprNotifications.Devices.DeviceCache
+
+  @behaviour WhisprNotifications.Devices.AuthClient
+
+  # compteur partage pour verifier le single-flight.
+  def reset_count do
+    if :ets.whereis(__MODULE__) == :undefined do
+      :ets.new(__MODULE__, [:public, :named_table])
+    end
+
+    :ets.insert(__MODULE__, {:count, 0})
+  end
+
+  def get_count do
+    case :ets.lookup(__MODULE__, :count) do
+      [{:count, n}] -> n
+      _ -> 0
+    end
+  end
+
+  @impl true
+  def fetch_devices(user_id) do
+    if :ets.whereis(__MODULE__) != :undefined do
+      :ets.update_counter(__MODULE__, :count, 1, {:count, 0})
+    end
+
+    Process.sleep(100)
+    {:ok, %DeviceCache{user_id: user_id, devices: []}}
+  end
+end
+
+defmodule WhisprNotifications.Devices.CacheManagerTest.HangingAuthClient do
+  @moduledoc false
+  alias WhisprNotifications.Devices.DeviceCache
+
+  @behaviour WhisprNotifications.Devices.AuthClient
+
+  @impl true
+  def fetch_devices(user_id) do
+    Process.sleep(5_000)
+    {:ok, %DeviceCache{user_id: user_id, devices: []}}
   end
 end


### PR DESCRIPTION
## Summary
- `CacheManager.handle_call({:get_cache, _}, ...)` ne bloque plus la mailbox du GenServer singleton: le fetch tourne dans un `Task.Supervisor.async_nolink`, le `handle_info` repond aux waiters via `GenServer.reply/2`.
- Coalescing single-flight: callers concurrents sur le meme `user_id` partagent un seul fetch reel (single-flight via map `inflight`).
- API publique inchangee, mais ajout d'un parametre `timeout` (default `3_000` ms, plus court que le `5_000` ms default de `GenServer.call`) pour que les call sites puissent couper court.
- Exit timeout traduit en `{:error, :timeout}` propre cote caller.

Avant: 50 messages d'un groupe = 50 `get_cache` serialises dans la mailbox -> cascade timeouts 5s -> livraison bloquee.
Apres: les 50 fetchs s'executent en parallele dans le Task.Supervisor, le test E2E confirme < 1s pour 50 user_ids distincts.

## Test plan
- [x] `mix test` green (494 tests, 0 failures)
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean (0 issues sur les fichiers touches)
- [x] Test concurrence: 50 fetchs paralleles avec mock 100ms -> total < 1s
- [x] Test single-flight: 10 callers concurrents = 1 seul fetch reel
- [x] Test cache hit < 10ms
- [x] Test timeout explicite -> `{:error, :timeout}` propre

Closes WHISPR-1361