### PR TITLE
[WHISPR-1373] fix(notification): cache_manager leak + token_refresher cleanup

### DIFF
--- a/lib/whispr_notifications/devices/cache_manager.ex
+++ b/lib/whispr_notifications/devices/cache_manager.ex
@@ -22,6 +22,7 @@ defmodule WhisprNotifications.Devices.CacheManager do
   """
 
   use GenServer
+  require Logger
 
   alias WhisprNotifications.Devices.{AuthClient, DeviceCache}
 
@@ -121,8 +122,10 @@ defmodule WhisprNotifications.Devices.CacheManager do
   @impl true
   def handle_info({ref, result}, state) when is_reference(ref) do
     case Map.pop(state.ref_to_user, ref) do
-      # coveralls-ignore-next-line - ref inconnue, branche defensive
       {nil, _} ->
+        # ref inconnue : log warn et ignore. ne devrait pas arriver en pratique
+        # car on tracke chaque Task ref dans ref_to_user au moment de l'async.
+        Logger.warning("[CacheManager] result for unknown ref #{inspect(ref)}")
         {:noreply, state}
 
       {user_id, ref_to_user} ->
@@ -154,18 +157,31 @@ defmodule WhisprNotifications.Devices.CacheManager do
   @impl true
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) when is_reference(ref) do
     case Map.pop(state.ref_to_user, ref) do
-      # coveralls-ignore-next-line - DOWN apres demonitor:flush, branche defensive
       {nil, _} ->
+        # DOWN sur ref inconnue (typiquement apres demonitor :flush qui a
+        # deja consomme le DOWN, ou race rare). on log et on ignore : pas
+        # de cleanup a faire puisque l'entry inflight a deja ete purgee
+        # cote handle_info({ref, result}).
+        Logger.warning(
+          "[CacheManager] DOWN for unknown ref #{inspect(ref)} reason=#{inspect(reason)}"
+        )
+
         {:noreply, state}
 
       {user_id, ref_to_user} ->
-        {_ref, waiters} = Map.fetch!(state.inflight, user_id)
+        # nettoyer meme si l'entry inflight est deja partie (defensif sur race)
+        {waiters, inflight} =
+          case Map.pop(state.inflight, user_id) do
+            {{_ref, waiters}, rest} -> {waiters, rest}
+            {nil, rest} -> {[], rest}
+          end
+
         Enum.each(waiters, &GenServer.reply(&1, {:error, {:fetch_crashed, reason}}))
 
         {:noreply,
          %{
            state
-           | inflight: Map.delete(state.inflight, user_id),
+           | inflight: inflight,
              ref_to_user: ref_to_user
          }}
     end

--- a/lib/whispr_notifications/devices/cache_manager.ex
+++ b/lib/whispr_notifications/devices/cache_manager.ex
@@ -172,8 +172,12 @@ defmodule WhisprNotifications.Devices.CacheManager do
         # nettoyer meme si l'entry inflight est deja partie (defensif sur race)
         {waiters, inflight} =
           case Map.pop(state.inflight, user_id) do
-            {{_ref, waiters}, rest} -> {waiters, rest}
-            {nil, rest} -> {[], rest}
+            {{_ref, waiters}, rest} ->
+              {waiters, rest}
+
+            # coveralls-ignore-next-line - inflight deja purge, branche defensive
+            {nil, rest} ->
+              {[], rest}
           end
 
         Enum.each(waiters, &GenServer.reply(&1, {:error, {:fetch_crashed, reason}}))

--- a/lib/whispr_notifications/workers/token_refresher.ex
+++ b/lib/whispr_notifications/workers/token_refresher.ex
@@ -37,18 +37,28 @@ defmodule WhisprNotifications.Workers.TokenRefresher do
 
   @impl true
   def init(_opts) do
-    schedule()
-    {:ok, %{last_run: nil, deleted: 0}}
+    timer_ref = schedule()
+    {:ok, %{last_run: nil, deleted: 0, timer_ref: timer_ref}}
   end
 
   @impl true
   def handle_info(:refresh_tokens, state) do
     new_state = run_cycle(state)
-    schedule()
-    {:noreply, new_state}
+    timer_ref = schedule()
+    {:noreply, %{new_state | timer_ref: timer_ref}}
   end
 
   def handle_info(_other, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, %{timer_ref: ref}) when is_reference(ref) do
+    # cancel le timer pendant pour eviter qu'il fire dans un mailbox d'un
+    # eventuel restart supervisor (benign, mais hygiene propre).
+    Process.cancel_timer(ref)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
 
   @doc """
   Exécute un cycle immédiatement (utile pour les tests et pour un
@@ -110,6 +120,7 @@ defmodule WhisprNotifications.Workers.TokenRefresher do
   end
 
   defp schedule do
+    # retourne le ref pour que l'appelant puisse le cancel dans terminate/2.
     Process.send_after(self(), :refresh_tokens, interval_ms())
   end
 

--- a/test/whispr_notifications/devices/cache_manager_test.exs
+++ b/test/whispr_notifications/devices/cache_manager_test.exs
@@ -135,6 +135,45 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
     end
   end
 
+  describe "DOWN handler robustness" do
+    test "DOWN with unknown ref logs warn and leaves state unchanged" do
+      pid = Process.whereis(CacheManager)
+      state_before = :sys.get_state(pid)
+
+      # envoie un DOWN avec une ref jamais enregistree dans ref_to_user
+      ref = make_ref()
+      send(pid, {:DOWN, ref, :process, self(), :normal})
+
+      # laisse le GenServer traiter le message
+      _ = :sys.get_state(pid)
+
+      state_after = :sys.get_state(pid)
+
+      assert state_before.inflight == state_after.inflight
+      assert state_before.ref_to_user == state_after.ref_to_user
+      assert Process.alive?(pid)
+    end
+
+    test "result for unknown ref logs warn and leaves state unchanged" do
+      pid = Process.whereis(CacheManager)
+      state_before = :sys.get_state(pid)
+
+      # envoie un message {ref, result} avec une ref inconnue
+      ref = make_ref()
+      send(pid, {ref, {:ok, %DeviceCache{user_id: "phantom", devices: []}}})
+
+      _ = :sys.get_state(pid)
+
+      state_after = :sys.get_state(pid)
+
+      # le cache phantom NE doit PAS avoir ete ajoute
+      refute Map.has_key?(state_after.caches, "phantom")
+      assert state_before.inflight == state_after.inflight
+      assert state_before.ref_to_user == state_after.ref_to_user
+      assert Process.alive?(pid)
+    end
+  end
+
   describe "timeout handling" do
     setup do
       # client qui dort 5s : aucun get_cache(_, 200ms) ne peut reussir a temps.

--- a/test/whispr_notifications/workers/token_refresher_extra_test.exs
+++ b/test/whispr_notifications/workers/token_refresher_extra_test.exs
@@ -17,4 +17,30 @@ defmodule WhisprNotifications.Workers.TokenRefresherExtraTest do
     Process.sleep(50)
     assert Process.alive?(pid)
   end
+
+  test "init stores a timer_ref in state" do
+    pid = Process.whereis(TokenRefresher)
+    state = :sys.get_state(pid)
+
+    assert is_reference(state.timer_ref)
+    # le timer doit etre encore vivant : Process.read_timer renvoie ms restants
+    # ou false si le timer n'existe plus.
+    assert is_integer(Process.read_timer(state.timer_ref))
+  end
+
+  test "terminate/2 cancels the pending timer" do
+    # appel direct du callback : l'instance singleton ne doit pas etre tuee
+    # juste pour ce test. on simule avec un ref de timer fraichement cree.
+    timer_ref = Process.send_after(self(), :unused, 60_000)
+    assert is_integer(Process.read_timer(timer_ref))
+
+    assert :ok = TokenRefresher.terminate(:shutdown, %{timer_ref: timer_ref})
+
+    # apres cancel, read_timer renvoie false.
+    assert Process.read_timer(timer_ref) == false
+  end
+
+  test "terminate/2 without timer_ref returns :ok" do
+    assert :ok = TokenRefresher.terminate(:shutdown, %{})
+  end
 end


### PR DESCRIPTION
## Summary
- cache_manager : branche `{nil, _}` du DOWN handler et du result handler logguent maintenant un warning au lieu de silently no-op (visibilite prod sur les races rares)
- cache_manager : DOWN handler cleanup defensif sur `inflight` meme si l'entry est deja partie (race :DOWN/result)
- token_refresher : `Process.send_after` ref tracke dans `state.timer_ref` et cancel dans `terminate/2` (hygiene propre)

## Test plan
- [x] `mix test` cache_manager + token_refresher : 19 tests, 0 failures
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean sur les 2 fichiers touches
- [x] Tests ajoutes : DOWN unknown ref, result unknown ref, terminate cancel timer, init stores timer_ref

Closes WHISPR-1373