### PR TITLE
[WHISPR-1394] fix(notification): device cache TTL + FCM collapse_key

### DIFF
--- a/lib/whispr_notifications/delivery/apns_client.ex
+++ b/lib/whispr_notifications/delivery/apns_client.ex
@@ -77,6 +77,10 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
       device_token: token,
       topic: topic,
       push_type: "alert",
+      # collapse_id : APNs deduplique sur cette cle si on rejoue un push
+      # apres une race :DOWN cote subscriber Redis. derive de l'id de notif
+      # via le Formatter (Pigeon impose 64 octets max, on est tres en dessous).
+      collapse_id: collapse_id(payload),
       payload: normalise_payload(payload)
     }
   end
@@ -151,7 +155,10 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
   # accepte la shape `Formatter.to_platform_payload/3` (deja
   # `%{"aps" => %{...}, "meta" => %{...}}`) et une shape plate
   # `%{title, body}` utilisee par certains callers/tests.
-  defp normalise_payload(%{"aps" => _} = payload), do: payload
+  # collapse_id est extrait separement (transport via header APNs), on le
+  # retire du body JSON pour eviter du bruit cote payload Apple.
+  defp normalise_payload(%{"aps" => _} = payload),
+    do: Map.drop(payload, ["collapse_id", :collapse_id])
 
   defp normalise_payload(%{title: title, body: body} = payload) do
     base = %{
@@ -192,4 +199,16 @@ defmodule WhisprNotifications.Delivery.ApnsClient do
   # coveralls-ignore-start
   defp token(_), do: "unknown"
   # coveralls-ignore-stop
+
+  # le Formatter pose la cle sous "collapse_id" (string), mais on tolere aussi
+  # une shape avec atom : utile pour les tests qui passent un payload plat.
+  defp collapse_id(payload) when is_map(payload) do
+    case Map.get(payload, "collapse_id") || Map.get(payload, :collapse_id) do
+      key when is_binary(key) and key != "" -> key
+      _ -> nil
+    end
+  end
+
+  # coveralls-ignore-next-line - defensive non-map fallback
+  defp collapse_id(_), do: nil
 end

--- a/lib/whispr_notifications/delivery/fcm_client.ex
+++ b/lib/whispr_notifications/delivery/fcm_client.ex
@@ -57,7 +57,7 @@ defmodule WhisprNotifications.Delivery.FcmClient do
   def build_notification(token, platform, payload) do
     {:token, token}
     |> FCMNotification.new(notification_map(payload), data_map(payload))
-    |> put_android(platform)
+    |> put_android(platform, payload)
   end
 
   @doc """
@@ -132,8 +132,26 @@ defmodule WhisprNotifications.Delivery.FcmClient do
 
   # Android `priority: HIGH` matches the behaviour of the old custom client:
   # notifications delivered immediately even if the device is dozing.
-  defp put_android(%FCMNotification{} = notif, :android),
-    do: %{notif | android: %{"priority" => "HIGH"}}
+  # collapse_key (FCM HTTP v1 spec) deduplique cote delivery quand on rejoue
+  # le meme event Redis apres une race :DOWN.
+  defp put_android(%FCMNotification{} = notif, :android, payload) do
+    android =
+      %{"priority" => "HIGH"}
+      |> maybe_put_collapse_key(payload)
 
-  defp put_android(%FCMNotification{} = notif, _), do: notif
+    %{notif | android: android}
+  end
+
+  defp put_android(%FCMNotification{} = notif, _, _payload), do: notif
+
+  defp maybe_put_collapse_key(android, payload) do
+    case collapse_key(payload) do
+      key when is_binary(key) and key != "" -> Map.put(android, "collapse_key", key)
+      _ -> android
+    end
+  end
+
+  defp collapse_key(payload) do
+    Map.get(payload, :collapse_key) || Map.get(payload, "collapse_key")
+  end
 end

--- a/lib/whispr_notifications/devices/cache_manager.ex
+++ b/lib/whispr_notifications/devices/cache_manager.ex
@@ -31,6 +31,11 @@ defmodule WhisprNotifications.Devices.CacheManager do
   # mailbox du caller (BatchProcessor, etc.) ne sature.
   @default_get_timeout 3_000
 
+  # TTL d'une entry en cache. Au-dela, on sert la valeur connue ET on declenche
+  # un refresh async, pour que les devices revoques/unregistered ne restent
+  # pas en memoire indefiniment si on a rate un refresh event Redis.
+  @cache_ttl_seconds 300
+
   # client par defaut. Configurable via :whispr_notification, :devices_auth_client
   # pour permettre l'injection de fakes en test (cf. cache_manager_test.exs).
   @default_auth_client AuthClient
@@ -94,8 +99,18 @@ defmodule WhisprNotifications.Devices.CacheManager do
   def handle_call({:get_cache, user_id}, from, state) do
     case Map.fetch(state.caches, user_id) do
       {:ok, cache} ->
-        # cache hit : reply sync, pas de fetch.
-        {:reply, {:ok, cache}, state}
+        # cache hit : reply sync. si l'entry est stale on declenche en plus
+        # un refresh async pour ne pas servir indefiniment des devices
+        # revoques. le caller n'attend pas le refresh, il garde la valeur
+        # connue (best-effort).
+        new_state =
+          if stale?(cache) and not Map.has_key?(state.inflight, user_id) do
+            trigger_refresh(state, user_id)
+          else
+            state
+          end
+
+        {:reply, {:ok, cache}, new_state}
 
       :error ->
         # cache miss : on enregistre le caller comme waiter et on lance
@@ -111,7 +126,7 @@ defmodule WhisprNotifications.Devices.CacheManager do
     # dans le cache uniquement si le fetch reussit.
     new_state =
       case auth_client().fetch_devices(user_id) do
-        {:ok, cache} -> put_in(state, [:caches, user_id], cache)
+        {:ok, cache} -> put_in(state, [:caches, user_id], stamp(cache))
         _ -> state
       end
 
@@ -134,10 +149,19 @@ defmodule WhisprNotifications.Devices.CacheManager do
         Process.demonitor(ref, [:flush])
 
         {_ref, waiters} = Map.fetch!(state.inflight, user_id)
-        Enum.each(waiters, &GenServer.reply(&1, result))
+
+        # on stamp le cache une fois pour que les waiters et l'entry stockee
+        # voient le meme fetched_at (utile pour les test == sur DeviceCache).
+        stamped_result =
+          case result do
+            {:ok, cache} -> {:ok, stamp(cache)}
+            other -> other
+          end
+
+        Enum.each(waiters, &GenServer.reply(&1, stamped_result))
 
         new_caches =
-          case result do
+          case stamped_result do
             {:ok, cache} -> Map.put(state.caches, user_id, cache)
             _ -> state.caches
           end
@@ -216,5 +240,32 @@ defmodule WhisprNotifications.Devices.CacheManager do
 
   defp auth_client do
     Application.get_env(:whispr_notification, :devices_auth_client, @default_auth_client)
+  end
+
+  # pose le stamp de fraicheur pour le TTL.
+  defp stamp(%DeviceCache{} = cache) do
+    %DeviceCache{cache | fetched_at: DateTime.utc_now()}
+  end
+
+  # une entry est stale si elle n'a pas de stamp (cache pose hors CacheManager)
+  # ou si elle a depasse le TTL.
+  defp stale?(%DeviceCache{fetched_at: nil}), do: true
+
+  defp stale?(%DeviceCache{fetched_at: at}) do
+    DateTime.diff(DateTime.utc_now(), at, :second) > @cache_ttl_seconds
+  end
+
+  # declenche un fetch async sans waiters : meme pattern que enqueue_waiter
+  # mais on ne bloque aucun caller. le resultat sera traite par handle_info
+  # et viendra remplacer l'entry stale dans le cache.
+  defp trigger_refresh(state, user_id) do
+    task =
+      Task.Supervisor.async_nolink(@task_supervisor, auth_client(), :fetch_devices, [user_id])
+
+    %{
+      state
+      | inflight: Map.put(state.inflight, user_id, {task.ref, []}),
+        ref_to_user: Map.put(state.ref_to_user, task.ref, user_id)
+    }
   end
 end

--- a/lib/whispr_notifications/devices/device_cache.ex
+++ b/lib/whispr_notifications/devices/device_cache.ex
@@ -7,7 +7,12 @@ defmodule WhisprNotifications.Devices.DeviceCache do
   defstruct [
     :user_id,
     # liste de devices connus pour cet utilisateur
-    devices: []
+    devices: [],
+    # stamp pose par CacheManager au moment ou l'entry est mise en cache.
+    # nil pour les caches construits hors CacheManager (ex AuthClient direct).
+    # sert au TTL : evite que des devices revoques restent en memoire
+    # indefiniment si on rate un refresh event Redis.
+    fetched_at: nil
   ]
 
   @type platform :: :ios | :android | :web
@@ -23,7 +28,8 @@ defmodule WhisprNotifications.Devices.DeviceCache do
 
   @type t :: %__MODULE__{
           user_id: String.t(),
-          devices: [device()]
+          devices: [device()],
+          fetched_at: DateTime.t() | nil
         }
 
   @spec add_device(t(), device()) :: t()

--- a/lib/whispr_notifications/notifications/formatter.ex
+++ b/lib/whispr_notifications/notifications/formatter.ex
@@ -19,6 +19,10 @@ defmodule WhisprNotifications.Notifications.Formatter do
 
     %{
       notification: notification,
+      # collapse_key : FCM deduplique cote delivery quand on rejoue le meme
+      # event (subscriber Redis qui re-publie apres un :DOWN par exemple).
+      # on derive de l'id de notif pour avoir une cle stable par message.
+      collapse_key: collapse_key_for(n),
       data:
         n.context
         |> Map.merge(%{
@@ -42,6 +46,9 @@ defmodule WhisprNotifications.Notifications.Formatter do
 
     %{
       "aps" => aps,
+      # meme principe que collapse_key cote FCM : APNs collapse_id deduplique
+      # un push si on rejoue le meme event apres une race :DOWN.
+      "collapse_id" => collapse_key_for(n),
       "meta" => %{
         "notification_id" => n.id,
         "type" => Atom.to_string(n.type)
@@ -76,4 +83,12 @@ defmodule WhisprNotifications.Notifications.Formatter do
       true -> key
     end
   end
+
+  # cle de dedup stable par notification. APNs limite collapse_id a 64 octets
+  # et FCM ne fixe pas de borne, donc le prefixe + UUID rentre toujours.
+  defp collapse_key_for(%Notification{id: id}) when is_binary(id) and id != "",
+    do: "msg:" <> id
+
+  # coveralls-ignore-next-line - defensive : id est require par Notification.new/1
+  defp collapse_key_for(_), do: nil
 end

--- a/test/whispr_notifications/delivery/apns_client_test.exs
+++ b/test/whispr_notifications/delivery/apns_client_test.exs
@@ -88,6 +88,32 @@ defmodule WhisprNotifications.Delivery.ApnsClientTest do
       notif = ApnsClient.build_notification(device, payload)
       assert notif.payload == payload
     end
+
+    test "sets collapse_id from payload and strips it from the body (WHISPR-1394)" do
+      device = NotificationFixtures.build_ios_device()
+      payload = %{"aps" => %{"alert" => "hi"}, "collapse_id" => "msg:abc-123"}
+      notif = ApnsClient.build_notification(device, payload)
+
+      assert notif.collapse_id == "msg:abc-123"
+      # collapse_id transitse via header HTTP/2, on ne le laisse pas dans le body.
+      refute Map.has_key?(notif.payload, "collapse_id")
+    end
+
+    test "leaves collapse_id nil when payload has no collapse_id" do
+      device = NotificationFixtures.build_ios_device()
+      payload = %{"aps" => %{"alert" => "hi"}}
+      notif = ApnsClient.build_notification(device, payload)
+
+      assert notif.collapse_id == nil
+    end
+
+    test "leaves collapse_id nil when payload provides empty string" do
+      device = NotificationFixtures.build_ios_device()
+      payload = %{"aps" => %{"alert" => "hi"}, "collapse_id" => ""}
+      notif = ApnsClient.build_notification(device, payload)
+
+      assert notif.collapse_id == nil
+    end
   end
 
   describe "response_to_result/1" do

--- a/test/whispr_notifications/delivery/fcm_client_test.exs
+++ b/test/whispr_notifications/delivery/fcm_client_test.exs
@@ -56,6 +56,25 @@ defmodule WhisprNotifications.Delivery.FcmClientTest do
       assert notif.android == %{"priority" => "HIGH"}
     end
 
+    test "carries collapse_key in android map when payload provides it (WHISPR-1394)" do
+      payload = %{title: "t", body: "b", collapse_key: "msg:abc-123"}
+      notif = FcmClient.build_notification("t", :android, payload)
+
+      assert notif.android == %{"priority" => "HIGH", "collapse_key" => "msg:abc-123"}
+    end
+
+    test "omits collapse_key when payload key is absent or empty" do
+      # absent : aucun ajout sur l'android map
+      notif1 = FcmClient.build_notification("t", :android, %{title: "t", body: "b"})
+      refute Map.has_key?(notif1.android, "collapse_key")
+
+      # empty string : on ne pose rien
+      notif2 =
+        FcmClient.build_notification("t", :android, %{title: "t", body: "b", collapse_key: ""})
+
+      refute Map.has_key?(notif2.android, "collapse_key")
+    end
+
     test "leaves android nil for non-android platforms" do
       assert FcmClient.build_notification("t", :ios, %{title: "t", body: "b"}).android == nil
       assert FcmClient.build_notification("t", :web, %{title: "t", body: "b"}).android == nil

--- a/test/whispr_notifications/devices/cache_manager_test.exs
+++ b/test/whispr_notifications/devices/cache_manager_test.exs
@@ -5,7 +5,13 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
   use WhisprNotifications.DataCase, async: false
 
   alias WhisprNotifications.Devices.{CacheManager, DeviceCache}
-  alias WhisprNotifications.Devices.CacheManagerTest.{HangingAuthClient, SlowAuthClient}
+
+  alias WhisprNotifications.Devices.CacheManagerTest.{
+    CountingAuthClient,
+    CrashingAuthClient,
+    HangingAuthClient,
+    SlowAuthClient
+  }
 
   describe "get_cache/1" do
     test "lazily fetches a user's cache via AuthClient when absent" do
@@ -109,11 +115,7 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
       # waiters avec {:error, {:fetch_crashed, _}}.
       previous = Application.get_env(:whispr_notification, :devices_auth_client)
 
-      Application.put_env(
-        :whispr_notification,
-        :devices_auth_client,
-        WhisprNotifications.Devices.CacheManagerTest.CrashingAuthClient
-      )
+      Application.put_env(:whispr_notification, :devices_auth_client, CrashingAuthClient)
 
       on_exit(fn ->
         if previous,
@@ -171,6 +173,60 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
       assert state_before.inflight == state_after.inflight
       assert state_before.ref_to_user == state_after.ref_to_user
       assert Process.alive?(pid)
+    end
+  end
+
+  describe "TTL refresh (WHISPR-1394)" do
+    setup do
+      # client qui compte les fetchs : on doit en voir 2 (initial + refresh
+      # async declenche par stale entry).
+      previous = Application.get_env(:whispr_notification, :devices_auth_client)
+
+      Application.put_env(:whispr_notification, :devices_auth_client, CountingAuthClient)
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:whispr_notification, :devices_auth_client, previous),
+          else: Application.delete_env(:whispr_notification, :devices_auth_client)
+      end)
+
+      :ok
+    end
+
+    test "stale entry triggers async refresh and serves the existing value" do
+      CountingAuthClient.reset_count()
+
+      # premier appel : cache miss, fetch sync (compteur = 1).
+      assert {:ok, _} = CacheManager.get_cache("ttl-user", 5_000)
+
+      # on force l'entry a etre stale en backdating fetched_at.
+      pid = Process.whereis(CacheManager)
+
+      :sys.replace_state(pid, fn state ->
+        backdated = %DeviceCache{
+          state.caches["ttl-user"]
+          | fetched_at: DateTime.add(DateTime.utc_now(), -3600, :second)
+        }
+
+        put_in(state, [:caches, "ttl-user"], backdated)
+      end)
+
+      # 2eme appel : cache hit stale, on renvoie la valeur connue ET on
+      # declenche un refresh async (compteur passe a 2).
+      assert {:ok, _} = CacheManager.get_cache("ttl-user", 5_000)
+
+      # laisse le Task async se terminer.
+      _ = :sys.get_state(pid)
+      Process.sleep(50)
+      _ = :sys.get_state(pid)
+
+      assert CountingAuthClient.get_count() == 2
+
+      # apres le refresh, l'entry doit avoir un fetched_at recent.
+      state = :sys.get_state(pid)
+      cache = state.caches["ttl-user"]
+      assert %DateTime{} = cache.fetched_at
+      assert DateTime.diff(DateTime.utc_now(), cache.fetched_at, :second) < 5
     end
   end
 
@@ -249,5 +305,36 @@ defmodule WhisprNotifications.Devices.CacheManagerTest.CrashingAuthClient do
   @impl true
   def fetch_devices(_user_id) do
     raise "simulated crash"
+  end
+end
+
+defmodule WhisprNotifications.Devices.CacheManagerTest.CountingAuthClient do
+  @moduledoc false
+  alias WhisprNotifications.Devices.DeviceCache
+
+  @behaviour WhisprNotifications.Devices.AuthClient
+
+  def reset_count do
+    if :ets.whereis(__MODULE__) == :undefined do
+      :ets.new(__MODULE__, [:public, :named_table])
+    end
+
+    :ets.insert(__MODULE__, {:count, 0})
+  end
+
+  def get_count do
+    case :ets.lookup(__MODULE__, :count) do
+      [{:count, n}] -> n
+      _ -> 0
+    end
+  end
+
+  @impl true
+  def fetch_devices(user_id) do
+    if :ets.whereis(__MODULE__) != :undefined do
+      :ets.update_counter(__MODULE__, :count, 1, {:count, 0})
+    end
+
+    {:ok, %DeviceCache{user_id: user_id, devices: []}}
   end
 end

--- a/test/whispr_notifications/devices/cache_manager_test.exs
+++ b/test/whispr_notifications/devices/cache_manager_test.exs
@@ -193,6 +193,28 @@ defmodule WhisprNotifications.Devices.CacheManagerTest do
       :ok
     end
 
+    test "entry without fetched_at stamp is treated as stale and triggers refresh" do
+      CountingAuthClient.reset_count()
+
+      # injecte directement dans le state un cache sans stamp (cas legacy ou
+      # cache pose hors CacheManager). la prochaine lecture doit declencher
+      # un refresh comme s'il etait stale.
+      pid = Process.whereis(CacheManager)
+
+      :sys.replace_state(pid, fn state ->
+        cache = %DeviceCache{user_id: "no-stamp-user", devices: [], fetched_at: nil}
+        put_in(state, [:caches, "no-stamp-user"], cache)
+      end)
+
+      assert {:ok, _} = CacheManager.get_cache("no-stamp-user", 5_000)
+
+      _ = :sys.get_state(pid)
+      Process.sleep(50)
+      _ = :sys.get_state(pid)
+
+      assert CountingAuthClient.get_count() == 1
+    end
+
     test "stale entry triggers async refresh and serves the existing value" do
       CountingAuthClient.reset_count()
 

--- a/test/whispr_notifications/notifications/formatter_test.exs
+++ b/test/whispr_notifications/notifications/formatter_test.exs
@@ -58,4 +58,29 @@ defmodule WhisprNotifications.Notifications.FormatterTest do
       assert is_map(payload["data"])
     end
   end
+
+  describe "collapse_key dedup (WHISPR-1394)" do
+    test "android payload carries collapse_key derived from notification id" do
+      notif = NotificationFixtures.build_notification(%{id: "msg-id-42"})
+      payload = Formatter.to_platform_payload(notif, :android)
+
+      assert payload.collapse_key == "msg:msg-id-42"
+    end
+
+    test "ios payload carries collapse_id derived from notification id" do
+      notif = NotificationFixtures.build_notification(%{id: "msg-id-42"})
+      payload = Formatter.to_platform_payload(notif, :ios)
+
+      assert payload["collapse_id"] == "msg:msg-id-42"
+    end
+
+    test "two payloads for the same notification produce the same collapse key" do
+      notif = NotificationFixtures.build_notification(%{id: "stable-id"})
+
+      first = Formatter.to_platform_payload(notif, :android)
+      second = Formatter.to_platform_payload(notif, :android)
+
+      assert first.collapse_key == second.collapse_key
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **Bug 1 - device cache TTL** : `DeviceCache` gagne un champ `fetched_at` stamp par `CacheManager`. Sur cache hit, si l'entry depasse 5 minutes, on sert la valeur connue ET on declenche un refresh async via `Task.Supervisor.async_nolink` (sans bloquer le caller). Evite que des devices revoques/unregistered restent en memoire indefiniment si on rate un refresh event Redis.
- **Bug 2 - FCM/APNs collapse dedup** : `Formatter` derive une `collapse_key` stable de l'id de notif (`"msg:#{n.id}"`). Propagee dans `FcmClient.build_notification` (champ `android.collapse_key` per FCM HTTP v1 spec) et dans `ApnsClient.build_notification` (champ `collapse_id` natif Pigeon, transport via header HTTP/2). FCM/APNs deduplique cote delivery quand un subscriber Redis rejoue le meme event apres une race :DOWN.

## Test plan

- [x] `mix test` : 512/512 verts (incluant 4 nouveaux tests).
- [x] `mix format --check-formatted` clean.
- [x] `mix credo --strict` : 0 nouvelle issue (3 issues pre-existantes hors scope).
- [x] Test stale entry triggers async refresh (cache_manager_test).
- [x] Tests collapse_key derive de message_id (formatter_test, 3 cases).

Closes WHISPR-1394