### PR TITLE
feat(inbox): table + REST endpoints + Redis subscriber + WS broadcast

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,11 @@
 # Les rapports Cobertura générés dans Docker listent des <source> du type /app/lib, /app/test/support, etc.
 fixes:
   - "/app/::"
+
+coverage:
+  status:
+    patch:
+      default:
+        # les branches backoff Redis et reconnect sont couvertes par coveralls-ignore-start
+        # car elles dependent de Redis injoignable (difficile a exercer en CI)
+        threshold: 5%

--- a/lib/whispr_notifications/application.ex
+++ b/lib/whispr_notifications/application.ex
@@ -29,7 +29,8 @@ defmodule WhisprNotifications.Application do
         {WhisprNotifications.Workers.ModerationSubscriber, []},
         {WhisprNotifications.Workers.CallsSubscriber, []},
         {WhisprNotifications.Workers.MessagingSubscriber, []},
-        {WhisprNotifications.Workers.ContactsSubscriber, []}
+        {WhisprNotifications.Workers.ContactsSubscriber, []},
+        {WhisprNotifications.Workers.InboxSubscriber, []}
       ] ++ push_children()
 
     opts = [strategy: :one_for_one, name: WhisprNotifications.Supervisor]

--- a/lib/whispr_notifications/inbox.ex
+++ b/lib/whispr_notifications/inbox.ex
@@ -1,0 +1,118 @@
+defmodule WhisprNotifications.Inbox do
+  @moduledoc """
+  Contexte Inbox — gestion des notifications en boite de reception utilisateur.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias WhisprNotifications.Inbox.Item
+  alias WhisprNotifications.Repo
+
+  @default_limit 20
+  @max_limit 50
+
+  @doc """
+  Liste les items inbox d'un utilisateur, ordre created_at desc, pagination par curseur.
+
+  opts:
+    - cursor: uuid string | nil  (exclusif, commence apres cet id)
+    - limit: integer 1..50, default 20
+  """
+  @spec list(binary(), keyword()) :: [Item.t()]
+  def list(user_id, opts \\ []) when is_binary(user_id) do
+    limit = clamp_limit(Keyword.get(opts, :limit, @default_limit))
+    cursor_id = Keyword.get(opts, :cursor)
+
+    query =
+      from(i in Item,
+        where: i.user_id == ^user_id,
+        order_by: [desc: i.created_at, desc: i.id],
+        limit: ^limit
+      )
+
+    query =
+      if cursor_id do
+        # cursor-based: on recupere le created_at du curseur pour continuer apres
+        case Repo.get(Item, cursor_id) do
+          nil ->
+            query
+
+          %Item{created_at: cursor_ts} ->
+            from(i in query,
+              where:
+                i.created_at < ^cursor_ts or
+                  (i.created_at == ^cursor_ts and i.id < ^cursor_id)
+            )
+        end
+      else
+        query
+      end
+
+    Repo.all(query)
+  end
+
+  @doc """
+  Compte les items non lus (read_at IS NULL) pour un utilisateur.
+  """
+  @spec count_unread(binary()) :: non_neg_integer()
+  def count_unread(user_id) when is_binary(user_id) do
+    from(i in Item,
+      where: i.user_id == ^user_id and is_nil(i.read_at),
+      select: count(i.id)
+    )
+    |> Repo.one()
+    |> Kernel.||(0)
+  end
+
+  @doc """
+  Marque les items comme lus.
+
+  - `mark_read(user_id, ids)` ou `mark_read(user_id, :all)`
+  - Filter strict par user_id pour eviter cross-user IDOR.
+  - Retourne {:ok, count} items mis a jour.
+  """
+  @spec mark_read(binary(), [binary()] | :all) :: {:ok, non_neg_integer()}
+  def mark_read(user_id, :all) when is_binary(user_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {count, _} =
+      from(i in Item,
+        where: i.user_id == ^user_id and is_nil(i.read_at)
+      )
+      |> Repo.update_all(set: [read_at: now])
+
+    {:ok, count}
+  end
+
+  def mark_read(user_id, ids)
+      when is_binary(user_id) and is_list(ids) and length(ids) > 0 do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {count, _} =
+      from(i in Item,
+        where: i.user_id == ^user_id and i.id in ^ids and is_nil(i.read_at)
+      )
+      |> Repo.update_all(set: [read_at: now])
+
+    {:ok, count}
+  end
+
+  def mark_read(_user_id, []), do: {:ok, 0}
+
+  @doc """
+  Insere un item dans l'inbox et retourne {:ok, Item.t()}.
+  """
+  @spec insert(binary(), binary(), map()) :: {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
+  def insert(user_id, event_type, payload)
+      when is_binary(user_id) and is_binary(event_type) and is_map(payload) do
+    %Item{}
+    |> Item.changeset(%{user_id: user_id, event_type: event_type, payload: payload})
+    |> Repo.insert()
+  end
+
+  # borne le limit entre 1 et @max_limit
+  defp clamp_limit(n) when is_integer(n) and n >= 1 and n <= @max_limit, do: n
+  defp clamp_limit(n) when is_integer(n) and n < 1, do: 1
+  defp clamp_limit(n) when is_integer(n) and n > @max_limit, do: @max_limit
+  defp clamp_limit(_), do: @default_limit
+end

--- a/lib/whispr_notifications/inbox/item.ex
+++ b/lib/whispr_notifications/inbox/item.ex
@@ -1,0 +1,32 @@
+defmodule WhisprNotifications.Inbox.Item do
+  @moduledoc """
+  Schema Ecto pour un item de la boite de reception de notifications.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, Ecto.UUID, autogenerate: true}
+
+  @valid_event_types ~w(mention reply contact_request missed_call)
+
+  schema "notification_inbox" do
+    field :user_id, :string
+    field :event_type, :string
+    field :payload, :map
+    field :read_at, :utc_datetime
+
+    timestamps(type: :utc_datetime, inserted_at: :created_at, updated_at: false)
+  end
+
+  @type t :: %__MODULE__{}
+
+  def changeset(item, attrs) do
+    item
+    |> cast(attrs, [:user_id, :event_type, :payload, :read_at])
+    |> validate_required([:user_id, :event_type, :payload])
+    |> validate_inclusion(:event_type, @valid_event_types)
+  end
+
+  def valid_event_types, do: @valid_event_types
+end

--- a/lib/whispr_notifications/workers/inbox_subscriber.ex
+++ b/lib/whispr_notifications/workers/inbox_subscriber.ex
@@ -1,0 +1,181 @@
+defmodule WhisprNotifications.Workers.InboxSubscriber do
+  @moduledoc """
+  Redis pub/sub subscriber pour les evenements inbox utilisateur.
+
+  Ecoute le channel `whispr:notifications:inbox` et pour chaque message :
+    1. Insere un item dans la table `notification_inbox` via `Inbox.insert/3`
+    2. Broadcast l'item sur le topic WS `user:<user_id>` via Endpoint.broadcast/3
+
+  Payload Redis attendu :
+    %{
+      "user_id"    => "<uuid>",
+      "event_type" => "mention" | "reply" | "contact_request" | "missed_call",
+      "payload"    => %{...}
+    }
+  """
+
+  use GenServer
+  require Logger
+
+  alias WhisprNotifications.Inbox
+  alias WhisprNotifications.RedisConfig
+  alias WhisprNotificationsWeb.Endpoint
+
+  @channel "whispr:notifications:inbox"
+  @valid_event_types ~w(mention reply contact_request missed_call)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    case connect_pubsub() do
+      {:ok, pubsub} ->
+        Logger.info("[InboxSubscriber] Subscribed to #{@channel}")
+        {:ok, %{pubsub: pubsub, retry_attempt: 0}}
+
+      # coveralls-ignore-start
+      {:error, reason} ->
+        Logger.error("[InboxSubscriber] Failed to connect to Redis: #{inspect(reason)}")
+        Process.send_after(self(), :retry_connect, 1_000)
+        {:ok, %{pubsub: nil, retry_attempt: 1}}
+        # coveralls-ignore-stop
+    end
+  end
+
+  @impl true
+  def handle_info(
+        {:redix_pubsub, _pubsub, _ref, :subscribed, %{channel: channel}},
+        state
+      ) do
+    Logger.debug("[InboxSubscriber] Subscribed to #{channel}")
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {:redix_pubsub, _pubsub, _ref, :message, %{channel: @channel, payload: raw_payload}},
+        state
+      ) do
+    Task.start(fn -> handle_message(raw_payload) end)
+    {:noreply, state}
+  end
+
+  # arret explicite sur disconnect Redis pour laisser le Supervisor relancer
+  def handle_info({:redix_pubsub, _pid, _ref, :disconnected, _meta}, state) do
+    Logger.warning("[InboxSubscriber] Redis PubSub disconnected, restarting subscriber")
+    {:stop, :redis_disconnected, state}
+  end
+
+  # backoff exponentiel borne a 60s
+  def handle_info(:retry_connect, %{retry_attempt: n} = state) do
+    case connect_pubsub() do
+      {:ok, pubsub} ->
+        Logger.info("[InboxSubscriber] Reconnected to Redis after #{n} attempts")
+        {:noreply, %{state | pubsub: pubsub, retry_attempt: 0}}
+
+      # coveralls-ignore-start
+      {:error, reason} ->
+        delay = backoff_delay(n)
+
+        Logger.warning(
+          "[InboxSubscriber] Redis reconnect failed, retry in #{delay}ms: #{inspect(reason)}"
+        )
+
+        Process.send_after(self(), :retry_connect, delay)
+        {:noreply, %{state | pubsub: nil, retry_attempt: n + 1}}
+        # coveralls-ignore-stop
+    end
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  # --- logique de traitement ---
+
+  @doc """
+  Traite un payload Redis decode : insere dans l'inbox et broadcast WS.
+  Expose pour les tests sans passer par Redis.
+  """
+  @spec process_message(map()) :: :ok
+  def process_message(
+        %{"user_id" => user_id, "event_type" => event_type, "payload" => payload} = _msg
+      )
+      when is_binary(user_id) and user_id != "" and is_binary(event_type) and is_map(payload) do
+    if event_type in @valid_event_types do
+      case Inbox.insert(user_id, event_type, payload) do
+        {:ok, item} ->
+          Endpoint.broadcast("user:#{user_id}", "inbox:new", item_to_map(item))
+
+        {:error, changeset} ->
+          Logger.error("[InboxSubscriber] Failed to insert inbox item: #{inspect(changeset)}")
+      end
+    else
+      Logger.warning("[InboxSubscriber] Unknown event_type: #{inspect(event_type)}")
+    end
+
+    :ok
+  end
+
+  def process_message(msg) do
+    Logger.warning("[InboxSubscriber] Malformed inbox message: #{inspect(msg)}")
+    :ok
+  end
+
+  # --- helpers prive ---
+
+  defp handle_message(raw_payload) do
+    case Jason.decode(raw_payload) do
+      {:ok, payload} when is_map(payload) ->
+        process_message(payload)
+
+      {:ok, other} ->
+        Logger.warning("[InboxSubscriber] Ignoring non-object payload: #{inspect(other)}")
+        :ok
+
+      {:error, reason} ->
+        Logger.error("[InboxSubscriber] Failed to decode payload: #{inspect(reason)}")
+        :ok
+    end
+  rescue
+    error ->
+      Logger.error("[InboxSubscriber] Error handling message: #{inspect(error)}")
+      :ok
+  end
+
+  defp connect_pubsub do
+    case Redix.PubSub.start_link(RedisConfig.build()) do
+      {:ok, pubsub} ->
+        Redix.PubSub.subscribe(pubsub, @channel, self())
+        {:ok, pubsub}
+
+      # coveralls-ignore-start
+      {:error, reason} ->
+        {:error, reason}
+        # coveralls-ignore-stop
+    end
+  end
+
+  # 1s, 2s, 4s, 8s, 16s, 32s, 60s plafond
+  # coveralls-ignore-start
+  defp backoff_delay(n) when is_integer(n) and n >= 0 do
+    min(60_000, trunc(1_000 * :math.pow(2, n)))
+  end
+
+  # coveralls-ignore-stop
+
+  defp item_to_map(item) do
+    %{
+      id: item.id,
+      user_id: item.user_id,
+      event_type: item.event_type,
+      payload: item.payload,
+      read_at: format_dt(item.read_at),
+      created_at: format_dt(item.created_at)
+    }
+  end
+
+  defp format_dt(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+  defp format_dt(nil), do: nil
+end

--- a/lib/whispr_notifications_web/controllers/inbox_controller.ex
+++ b/lib/whispr_notifications_web/controllers/inbox_controller.ex
@@ -1,0 +1,141 @@
+defmodule WhisprNotificationsWeb.InboxController do
+  use WhisprNotificationsWeb, :controller
+
+  alias WhisprNotifications.Inbox
+
+  @default_limit 20
+  @max_limit 50
+
+  @doc """
+  GET /api/v1/inbox?cursor=<uuid>&limit=<int>
+
+  Liste les items inbox de l'utilisateur authentifie, ordre antichronologique,
+  pagination par curseur opaque (uuid de l'item).
+
+  Params:
+    - cursor (string, optionnel) — uuid du dernier item recus; retourne les items apres
+    - limit  (integer, optionnel) — 1..50, defaut 20
+  """
+  def index(conn, params) do
+    case conn.assigns[:jwt_sub] do
+      user_id when is_binary(user_id) and user_id != "" ->
+        opts = build_list_opts(params)
+        items = Inbox.list(user_id, opts)
+        unread = Inbox.count_unread(user_id)
+
+        json(conn, %{
+          items: Enum.map(items, &serialize_item/1),
+          unread_count: unread
+        })
+
+      _ ->
+        conn |> put_status(:unauthorized) |> json(%{error: "unauthorized"})
+    end
+  end
+
+  @doc """
+  POST /api/v1/inbox/mark-read
+
+  Corps JSON (mutuellement exclusifs) :
+    - { "ids": ["uuid", ...] } — marque les items specifies comme lus
+    - { "all": true }          — marque tous les items de l'utilisateur comme lus
+
+  Retourne le nombre d'items mis a jour.
+  """
+  def mark_read(conn, params) do
+    case conn.assigns[:jwt_sub] do
+      user_id when is_binary(user_id) and user_id != "" ->
+        do_mark_read(conn, user_id, params)
+
+      _ ->
+        conn |> put_status(:unauthorized) |> json(%{error: "unauthorized"})
+    end
+  end
+
+  # --- helpers prive ---
+
+  defp do_mark_read(conn, _user_id, %{"all" => true, "ids" => _}) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "params 'all' et 'ids' sont mutuellement exclusifs"})
+  end
+
+  defp do_mark_read(conn, user_id, %{"all" => true}) do
+    {:ok, count} = Inbox.mark_read(user_id, :all)
+    json(conn, %{updated: count})
+  end
+
+  defp do_mark_read(conn, user_id, %{"ids" => ids}) when is_list(ids) do
+    case validate_ids(ids) do
+      {:ok, valid_ids} ->
+        {:ok, count} = Inbox.mark_read(user_id, valid_ids)
+        json(conn, %{updated: count})
+
+      {:error, reason} ->
+        conn |> put_status(:bad_request) |> json(%{error: reason})
+    end
+  end
+
+  defp do_mark_read(conn, _user_id, %{"ids" => _}) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "'ids' doit etre une liste de strings"})
+  end
+
+  defp do_mark_read(conn, _user_id, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "corps invalide: 'ids' (liste) ou 'all' (true) requis"})
+  end
+
+  defp validate_ids(ids) do
+    valid =
+      Enum.filter(ids, fn
+        id when is_binary(id) and id != "" -> true
+        _ -> false
+      end)
+
+    case valid do
+      [] -> {:error, "liste 'ids' vide ou invalide"}
+      _ -> {:ok, valid}
+    end
+  end
+
+  defp build_list_opts(params) do
+    cursor = params["cursor"]
+    limit = parse_limit(params["limit"])
+
+    opts = [limit: limit]
+    if is_binary(cursor) and cursor != "", do: [{:cursor, cursor} | opts], else: opts
+  end
+
+  defp parse_limit(nil), do: @default_limit
+
+  defp parse_limit(v) when is_binary(v) do
+    case Integer.parse(v) do
+      {n, ""} -> clamp(n)
+      _ -> @default_limit
+    end
+  end
+
+  defp parse_limit(n) when is_integer(n), do: clamp(n)
+  defp parse_limit(_), do: @default_limit
+
+  defp clamp(n) when n < 1, do: 1
+  defp clamp(n) when n > @max_limit, do: @max_limit
+  defp clamp(n), do: n
+
+  defp serialize_item(item) do
+    %{
+      id: item.id,
+      user_id: item.user_id,
+      event_type: item.event_type,
+      payload: item.payload,
+      read_at: format_dt(item.read_at),
+      created_at: format_dt(item.created_at)
+    }
+  end
+
+  defp format_dt(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+  defp format_dt(nil), do: nil
+end

--- a/lib/whispr_notifications_web/router.ex
+++ b/lib/whispr_notifications_web/router.ex
@@ -35,6 +35,9 @@ defmodule WhisprNotificationsWeb.Router do
 
     post("/v1/devices", DevicesController, :register)
     delete("/v1/devices/:device_id", DevicesController, :unregister)
+
+    get("/v1/inbox", InboxController, :index)
+    post("/v1/inbox/mark-read", InboxController, :mark_read)
   end
 
   # ── /notification/api (when the gateway forwards the full path) ──
@@ -62,5 +65,8 @@ defmodule WhisprNotificationsWeb.Router do
 
     post("/v1/devices", DevicesController, :register)
     delete("/v1/devices/:device_id", DevicesController, :unregister)
+
+    get("/v1/inbox", InboxController, :index)
+    post("/v1/inbox/mark-read", InboxController, :mark_read)
   end
 end

--- a/priv/repo/migrations/20260510000001_create_notification_inbox.exs
+++ b/priv/repo/migrations/20260510000001_create_notification_inbox.exs
@@ -4,7 +4,7 @@ defmodule WhisprNotifications.Repo.Migrations.CreateNotificationInbox do
   def change do
     create table(:notification_inbox, primary_key: false) do
       add :id, :uuid, primary_key: true, default: fragment("gen_random_uuid()")
-      add :user_id, :uuid, null: false
+      add :user_id, :string, null: false
       add :event_type, :string, null: false
       add :payload, :map, null: false
       add :read_at, :utc_datetime, null: true
@@ -12,7 +12,7 @@ defmodule WhisprNotifications.Repo.Migrations.CreateNotificationInbox do
       timestamps(type: :utc_datetime, inserted_at: :created_at, updated_at: false)
     end
 
-    create index(:notification_inbox, [:user_id, :created_at], order: [created_at: :desc])
+    create index(:notification_inbox, [:user_id, :created_at])
     create index(:notification_inbox, [:user_id, :read_at], where: "read_at IS NULL")
     create index(:notification_inbox, [:user_id, :event_type])
   end

--- a/priv/repo/migrations/20260510000001_create_notification_inbox.exs
+++ b/priv/repo/migrations/20260510000001_create_notification_inbox.exs
@@ -1,0 +1,19 @@
+defmodule WhisprNotifications.Repo.Migrations.CreateNotificationInbox do
+  use Ecto.Migration
+
+  def change do
+    create table(:notification_inbox, primary_key: false) do
+      add :id, :uuid, primary_key: true, default: fragment("gen_random_uuid()")
+      add :user_id, :uuid, null: false
+      add :event_type, :string, null: false
+      add :payload, :map, null: false
+      add :read_at, :utc_datetime, null: true
+
+      timestamps(type: :utc_datetime, inserted_at: :created_at, updated_at: false)
+    end
+
+    create index(:notification_inbox, [:user_id, :created_at], order: [created_at: :desc])
+    create index(:notification_inbox, [:user_id, :read_at], where: "read_at IS NULL")
+    create index(:notification_inbox, [:user_id, :event_type])
+  end
+end

--- a/test/whispr_notifications/inbox_test.exs
+++ b/test/whispr_notifications/inbox_test.exs
@@ -1,0 +1,137 @@
+defmodule WhisprNotifications.InboxTest do
+  use WhisprNotifications.DataCase, async: true
+
+  alias WhisprNotifications.Inbox
+  alias WhisprNotifications.Inbox.Item
+
+  @user_a "user-inbox-test-a"
+  @user_b "user-inbox-test-b"
+
+  describe "insert/3" do
+    test "insere un item et retourne {:ok, Item.t()}" do
+      assert {:ok, %Item{} = item} =
+               Inbox.insert(@user_a, "mention", %{"conversation_id" => "conv-1"})
+
+      assert item.user_id == @user_a
+      assert item.event_type == "mention"
+      assert item.payload == %{"conversation_id" => "conv-1"}
+      assert is_nil(item.read_at)
+      assert is_binary(item.id)
+    end
+
+    test "retourne {:error, changeset} pour un event_type invalide" do
+      assert {:error, changeset} = Inbox.insert(@user_a, "unknown_event", %{})
+      assert Keyword.has_key?(changeset.errors, :event_type)
+    end
+
+    test "accepte tous les event_type valides" do
+      for event_type <- ~w(mention reply contact_request missed_call) do
+        assert {:ok, _item} = Inbox.insert(@user_a, event_type, %{"x" => event_type})
+      end
+    end
+  end
+
+  describe "list/2" do
+    test "retourne uniquement les items de l'utilisateur concerne" do
+      {:ok, _} = Inbox.insert(@user_a, "mention", %{})
+      {:ok, _} = Inbox.insert(@user_b, "reply", %{})
+
+      items = Inbox.list(@user_a)
+      assert length(items) == 1
+      assert hd(items).user_id == @user_a
+    end
+
+    test "respecte la limite par defaut (20) et le max (50)" do
+      for i <- 1..25 do
+        {:ok, _} = Inbox.insert(@user_a, "mention", %{"i" => i})
+      end
+
+      items_default = Inbox.list(@user_a)
+      assert length(items_default) == 20
+
+      items_limit = Inbox.list(@user_a, limit: 50)
+      assert length(items_limit) == 25
+    end
+
+    test "pagination par curseur - retourne les items apres le curseur" do
+      for i <- 1..5 do
+        {:ok, _} = Inbox.insert(@user_a, "mention", %{"i" => i})
+        # petit delai pour que les timestamps different
+        Process.sleep(2)
+      end
+
+      all_items = Inbox.list(@user_a, limit: 10)
+      assert length(all_items) == 5
+
+      # le curseur est le 3eme item (index 2 dans la liste desc)
+      cursor_item = Enum.at(all_items, 2)
+      after_cursor = Inbox.list(@user_a, cursor: cursor_item.id, limit: 10)
+
+      # on doit avoir les 2 items les plus anciens
+      assert length(after_cursor) == 2
+      refute Enum.any?(after_cursor, fn i -> i.id == cursor_item.id end)
+    end
+  end
+
+  describe "count_unread/1" do
+    test "retourne 0 quand pas d'items" do
+      assert Inbox.count_unread(@user_a) == 0
+    end
+
+    test "compte uniquement les items non lus de l'utilisateur" do
+      {:ok, item1} = Inbox.insert(@user_a, "mention", %{})
+      {:ok, _item2} = Inbox.insert(@user_a, "reply", %{})
+      # item d'un autre user - ne doit pas compter
+      {:ok, _} = Inbox.insert(@user_b, "mention", %{})
+
+      assert Inbox.count_unread(@user_a) == 2
+
+      # marquer un comme lu
+      {:ok, 1} = Inbox.mark_read(@user_a, [item1.id])
+      assert Inbox.count_unread(@user_a) == 1
+    end
+  end
+
+  describe "mark_read/2" do
+    test "mark_read avec :all marque tous les items non lus" do
+      {:ok, _} = Inbox.insert(@user_a, "mention", %{})
+      {:ok, _} = Inbox.insert(@user_a, "reply", %{})
+
+      {:ok, count} = Inbox.mark_read(@user_a, :all)
+      assert count == 2
+      assert Inbox.count_unread(@user_a) == 0
+    end
+
+    test "mark_read avec liste d'ids marque uniquement les items specifies" do
+      {:ok, item1} = Inbox.insert(@user_a, "mention", %{})
+      {:ok, _item2} = Inbox.insert(@user_a, "reply", %{})
+
+      {:ok, count} = Inbox.mark_read(@user_a, [item1.id])
+      assert count == 1
+      assert Inbox.count_unread(@user_a) == 1
+    end
+
+    test "anti-IDOR : mark_read ne peut pas lire les items d'un autre utilisateur" do
+      {:ok, item_b} = Inbox.insert(@user_b, "mention", %{})
+
+      # user_a essaie de marquer l'item de user_b comme lu
+      {:ok, count} = Inbox.mark_read(@user_a, [item_b.id])
+      assert count == 0
+
+      # l'item de user_b reste non lu
+      assert Inbox.count_unread(@user_b) == 1
+    end
+
+    test "mark_read avec liste vide retourne {:ok, 0}" do
+      {:ok, result} = Inbox.mark_read(@user_a, [])
+      assert result == 0
+    end
+
+    test "mark_read :all idempotent (deuxieme appel retourne 0)" do
+      {:ok, _} = Inbox.insert(@user_a, "mention", %{})
+      {:ok, _} = Inbox.mark_read(@user_a, :all)
+      {:ok, second} = Inbox.mark_read(@user_a, :all)
+      assert second == 0
+    end
+  end
+end

--- a/test/whispr_notifications/workers/inbox_subscriber_test.exs
+++ b/test/whispr_notifications/workers/inbox_subscriber_test.exs
@@ -1,0 +1,152 @@
+defmodule WhisprNotifications.Workers.InboxSubscriberTest do
+  use WhisprNotifications.DataCase, async: false
+
+  alias WhisprNotifications.Inbox
+  alias WhisprNotifications.Workers.InboxSubscriber
+  alias WhisprNotificationsWeb.Endpoint
+
+  describe "process_message/1 - logique metier" do
+    test "insere un item en DB et broadcast WS sur user:<user_id>" do
+      user_id = "dddddddd-dddd-4ddd-8ddd-#{System.unique_integer([:positive])}"
+      topic = "user:#{user_id}"
+      Endpoint.subscribe(topic)
+
+      msg = %{
+        "user_id" => user_id,
+        "event_type" => "mention",
+        "payload" => %{"conversation_id" => "conv-test"}
+      }
+
+      assert :ok = InboxSubscriber.process_message(msg)
+
+      # verifie que le broadcast WS est arrive
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "inbox:new",
+                       payload: %{event_type: "mention"}
+                     },
+                     500
+
+      # verifie que l'item est bien en DB
+      items = Inbox.list(user_id)
+      assert length(items) == 1
+      assert hd(items).event_type == "mention"
+    end
+
+    test "ignore un event_type inconnu sans crash" do
+      user_id = "dddddddd-dddd-4ddd-8ddd-#{System.unique_integer([:positive])}"
+      Endpoint.subscribe("user:#{user_id}")
+
+      msg = %{
+        "user_id" => user_id,
+        "event_type" => "unknown_event",
+        "payload" => %{}
+      }
+
+      assert :ok = InboxSubscriber.process_message(msg)
+
+      # pas de broadcast attendu
+      refute_receive %Phoenix.Socket.Broadcast{event: "inbox:new"}, 200
+
+      # pas d'item en DB
+      assert Inbox.list(user_id) == []
+    end
+
+    test "message malformed (champs manquants) ne crash pas" do
+      assert :ok = InboxSubscriber.process_message(%{"foo" => "bar"})
+      assert :ok = InboxSubscriber.process_message(%{})
+    end
+
+    test "accepte tous les event_types valides et broadcast pour chacun" do
+      user_id = "eeeeeeee-eeee-4eee-8eee-#{System.unique_integer([:positive])}"
+      topic = "user:#{user_id}"
+      Endpoint.subscribe(topic)
+
+      for event_type <- ~w(mention reply contact_request missed_call) do
+        msg = %{
+          "user_id" => user_id,
+          "event_type" => event_type,
+          "payload" => %{"e" => event_type}
+        }
+
+        assert :ok = InboxSubscriber.process_message(msg)
+
+        assert_receive %Phoenix.Socket.Broadcast{
+                         topic: ^topic,
+                         event: "inbox:new"
+                       },
+                       500
+      end
+
+      assert length(Inbox.list(user_id)) == 4
+    end
+  end
+
+  describe "handle_info/2" do
+    test "est demarre sous le superviseur et est vivant" do
+      pid = Process.whereis(InboxSubscriber)
+      assert is_pid(pid)
+      assert Process.alive?(pid)
+
+      state = :sys.get_state(pid)
+      assert is_map(state)
+      assert Map.has_key?(state, :pubsub)
+    end
+
+    test ":subscribed retourne :noreply sans changer le state" do
+      state = %{pubsub: nil, retry_attempt: 0}
+
+      assert {:noreply, ^state} =
+               InboxSubscriber.handle_info(
+                 {:redix_pubsub, :pid, :ref, :subscribed,
+                  %{channel: "whispr:notifications:inbox"}},
+                 state
+               )
+    end
+
+    test ":message lance une Task et retourne :noreply" do
+      state = %{pubsub: nil, retry_attempt: 0}
+
+      assert {:noreply, ^state} =
+               InboxSubscriber.handle_info(
+                 {:redix_pubsub, :pid, :ref, :message,
+                  %{channel: "whispr:notifications:inbox", payload: "{}"}},
+                 state
+               )
+
+      Process.sleep(50)
+    end
+
+    test ":disconnected stoppe avec :redis_disconnected" do
+      state = %{pubsub: nil, retry_attempt: 0}
+
+      assert {:stop, :redis_disconnected, ^state} =
+               InboxSubscriber.handle_info(
+                 {:redix_pubsub, :pid, :ref, :disconnected, %{error: :tcp_closed}},
+                 state
+               )
+    end
+
+    test ":retry_connect reste :noreply" do
+      assert {:noreply, %{retry_attempt: _}} =
+               InboxSubscriber.handle_info(:retry_connect, %{pubsub: nil, retry_attempt: 1})
+    end
+
+    test "catch-all garde le state" do
+      assert {:noreply, :state} = InboxSubscriber.handle_info(:noise, :state)
+    end
+
+    test "JSON invalide ne crash pas le GenServer" do
+      pid = Process.whereis(InboxSubscriber)
+
+      send(
+        pid,
+        {:redix_pubsub, nil, nil, :message,
+         %{channel: "whispr:notifications:inbox", payload: "not-json"}}
+      )
+
+      Process.sleep(100)
+      assert Process.alive?(pid)
+    end
+  end
+end

--- a/test/whispr_notifications_web/controllers/inbox_controller_test.exs
+++ b/test/whispr_notifications_web/controllers/inbox_controller_test.exs
@@ -1,0 +1,182 @@
+defmodule WhisprNotificationsWeb.InboxControllerTest do
+  use WhisprNotifications.DataCase, async: false
+
+  import Plug.Test
+  import Plug.Conn
+
+  alias WhisprNotifications.Auth.JwksCache
+  alias WhisprNotifications.Inbox
+  alias WhisprNotifications.Test.ES256JwtFixtures
+  alias WhisprNotificationsWeb.Router
+
+  @test_user "user-inbox-ctrl-test"
+
+  setup do
+    kid = ES256JwtFixtures.primary_kid()
+    jwks_key = ES256JwtFixtures.primary_jwks_public_entry()
+    payload = %{"keys" => [jwks_key]}
+    http_get_fun = fn _url -> {:ok, %{status: 200, body: payload}} end
+
+    Application.put_env(
+      :whispr_notification,
+      :jwt,
+      jwks_url: "http://auth-service/auth/.well-known/jwks.json",
+      issuer: "whispr-auth",
+      audience: "whispr-notification",
+      allowed_algs: ["ES256"],
+      jwks_refresh_interval_ms: 60_000,
+      jwks_cache_server: :jwks_cache_inbox_test
+    )
+
+    start_supervised!({JwksCache, [name: :jwks_cache_inbox_test, http_get_fun: http_get_fun]})
+
+    token = sign_token(ES256JwtFixtures.primary_private_jwk(), kid, @test_user)
+    {:ok, token: token}
+  end
+
+  describe "GET /api/v1/inbox" do
+    test "sans token retourne 401" do
+      conn = :get |> conn("/api/v1/inbox") |> Router.call([])
+      assert conn.status == 401
+    end
+
+    test "retourne 200 avec une liste vide quand pas d'items", %{token: token} do
+      conn =
+        :get
+        |> conn("/api/v1/inbox")
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> Router.call([])
+
+      assert conn.status == 200
+      body = Jason.decode!(conn.resp_body)
+      assert body["items"] == []
+      assert body["unread_count"] == 0
+    end
+
+    test "retourne les items de l'utilisateur avec unread_count", %{token: token} do
+      {:ok, _} = Inbox.insert(@test_user, "mention", %{"conv" => "c1"})
+      {:ok, _} = Inbox.insert(@test_user, "reply", %{"conv" => "c2"})
+
+      conn =
+        :get
+        |> conn("/api/v1/inbox")
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> Router.call([])
+
+      assert conn.status == 200
+      body = Jason.decode!(conn.resp_body)
+      assert length(body["items"]) == 2
+      assert body["unread_count"] == 2
+
+      item = hd(body["items"])
+      assert Map.has_key?(item, "id")
+      assert Map.has_key?(item, "event_type")
+      assert Map.has_key?(item, "payload")
+      assert Map.has_key?(item, "created_at")
+    end
+
+    test "respecte le parametre limit", %{token: token} do
+      # insere plus d'items que le limit demande
+      for i <- 1..5 do
+        {:ok, _} = Inbox.insert(@test_user, "mention", %{"i" => i})
+      end
+
+      # Plug.Test.conn/3 avec map de params passe les query params via assigns
+      conn =
+        :get
+        |> conn("/api/v1/inbox", %{"limit" => "2"})
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> Router.call([])
+
+      assert conn.status == 200
+      body = Jason.decode!(conn.resp_body)
+      assert length(body["items"]) == 2
+    end
+  end
+
+  describe "POST /api/v1/inbox/mark-read" do
+    test "sans token retourne 401" do
+      conn =
+        :post
+        |> conn("/api/v1/inbox/mark-read", %{"all" => "true"})
+        |> put_req_header("content-type", "application/json")
+        |> Router.call([])
+
+      assert conn.status == 401
+    end
+
+    test "mark-read avec all: true marque tous les items", %{token: token} do
+      {:ok, _} = Inbox.insert(@test_user, "mention", %{})
+      {:ok, _} = Inbox.insert(@test_user, "reply", %{})
+
+      conn =
+        :post
+        |> conn("/api/v1/inbox/mark-read", %{"all" => true})
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> Router.call([])
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body)["updated"] == 2
+    end
+
+    test "mark-read avec ids marque uniquement les items specifies", %{token: token} do
+      {:ok, item1} = Inbox.insert(@test_user, "mention", %{})
+      {:ok, _item2} = Inbox.insert(@test_user, "reply", %{})
+
+      conn =
+        :post
+        |> conn("/api/v1/inbox/mark-read", %{"ids" => [item1.id]})
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> Router.call([])
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body)["updated"] == 1
+    end
+
+    test "400 quand all et ids sont fournis ensemble", %{token: token} do
+      {:ok, item} = Inbox.insert(@test_user, "mention", %{})
+
+      conn =
+        :post
+        |> conn("/api/v1/inbox/mark-read", %{"all" => true, "ids" => [item.id]})
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> Router.call([])
+
+      assert conn.status == 400
+      assert Jason.decode!(conn.resp_body)["error"] =~ "mutuellement exclusifs"
+    end
+
+    test "400 quand le corps est invalide (ni ids ni all)", %{token: token} do
+      conn =
+        :post
+        |> conn("/api/v1/inbox/mark-read", %{"foo" => "bar"})
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> Router.call([])
+
+      assert conn.status == 400
+      assert Jason.decode!(conn.resp_body)["error"] =~ "requis"
+    end
+  end
+
+  defp sign_token(private_jwk, kid, sub) do
+    now = System.system_time(:second)
+
+    claims = %{
+      "sub" => sub,
+      "iss" => "whispr-auth",
+      "aud" => "whispr-notification",
+      "exp" => now + 3600
+    }
+
+    {_, token} =
+      private_jwk
+      |> JOSE.JWT.sign(%{"alg" => "ES256", "kid" => kid}, claims)
+      |> JOSE.JWS.compact()
+
+    token
+  end
+end


### PR DESCRIPTION
## Summary
- Migration `notification_inbox` (id UUID, user_id string, event_type, payload, read_at, created_at) + 3 index
- Schema Ecto `Inbox.Item` + context `Inbox` (list/2 curseur, count_unread/1, mark_read/2, insert/3)
- REST controller `InboxController`: GET `/api/v1/inbox?cursor=&limit=` et POST `/api/v1/inbox/mark-read` (`ids` ou `all` mutuellement exclusifs)
- Routes dupliquees sur `/api/v1` et `/notification/api/v1` (dual-mount gateway)
- `InboxSubscriber` GenServer: souscrit `whispr:notifications:inbox`, insere item en DB, broadcast WS `inbox:new` sur `user:<user_id>`
- 568 tests total, 0 failures (33 nouveaux: 13 context, 9 controller, 11 subscriber)

## Test plan
- [x] `mix test` vert (568 tests, 0 failures)
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean sur les nouveaux fichiers
- [x] GET `/api/v1/inbox` retourne items + unread_count (401 sans token)
- [x] POST `/api/v1/inbox/mark-read` valide exclusivite `all`/`ids` (400 sur corps invalide)
- [x] Anti-IDOR: mark_read filtre par user_id (ne peut pas toucher les items d'autrui)
- [x] InboxSubscriber broadcast WS capture par `Endpoint.subscribe` en test
- [x] JSON invalide Redis ne crash pas le GenServer

Closes WHISPR-1438