### PR TITLE
fix(config): VAPID chargé au runtime + message_push_enabled vérifié

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -91,19 +91,10 @@ config :whispr_notification, :services,
 # Web Push VAPID
 # ======================================================================
 #
-# Clés générées avec `web_push_elixir.generate_vapid_keys` ou openssl.
-# VAPID_SUBJECT doit être une URL mailto: ou https:.
+# Les clés VAPID viennent des secrets Kubernetes et ne sont pas disponibles
+# au build Docker. La config :web_push_elixir est dans runtime.exs pour que
+# System.get_env soit évalué au démarrage du pod, pas lors du mix release.
 # En dev/CI les clés sont absentes — le WebPushClient retourne :not_configured.
-
-# web_push_elixir attend 3 clés plates (pas un nested map) :
-#   vapid_subject   → URL mailto: ou https: identifiant le serveur
-#   vapid_public_key  → clé ECDH P-256 publique en base64url (sans padding)
-#   vapid_private_key → clé ECDH P-256 privée en base64url (sans padding)
-# Générer avec : mix web_push_elixir.generate_vapid_keys
-config :web_push_elixir,
-  vapid_subject: System.get_env("VAPID_SUBJECT", ""),
-  vapid_public_key: System.get_env("VAPID_PUBLIC_KEY", ""),
-  vapid_private_key: System.get_env("VAPID_PRIVATE_KEY", "")
 
 # ======================================================================
 # Logger

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -225,3 +225,13 @@ if apns_enabled? do
     team_id: apns_team_id,
     mode: apns_mode
 end
+
+# Web Push VAPID — lu au runtime pour que les secrets Kubernetes soient
+# disponibles (config.exs est évalué au build Docker, pas au démarrage).
+# web_push_elixir attend des clés P-256 en base64url sans padding.
+# WebPushClient.send/2 retourne {:error, :not_configured} si les deux
+# clés sont absentes (dev/CI sans secret).
+config :web_push_elixir,
+  vapid_subject: System.get_env("VAPID_SUBJECT", ""),
+  vapid_public_key: System.get_env("VAPID_PUBLIC_KEY", ""),
+  vapid_private_key: System.get_env("VAPID_PRIVATE_KEY", "")

--- a/lib/whispr_notifications/preferences/manager.ex
+++ b/lib/whispr_notifications/preferences/manager.ex
@@ -109,11 +109,29 @@ defmodule WhisprNotifications.Preferences.Manager do
       end
 
     user_ok = is_nil(user_settings) or not UserSettings.quiet_now?(user_settings, now)
+    push_enabled_ok = push_enabled_for?(notif, user_settings)
     conv_ok = is_nil(conv_settings) or not ConversationSettings.muted_now?(conv_settings, now)
     mention_ok = mention_allowed?(notif, user_settings, conv_settings)
 
-    user_ok and conv_ok and mention_ok
+    user_ok and push_enabled_ok and conv_ok and mention_ok
   end
+
+  # Vérifie le toggle push_enabled correspondant au type de la notification.
+  # Un toggle à false bloque l'envoi même si quiet_hours ne s'applique pas.
+  defp push_enabled_for?(_notif, nil), do: true
+
+  defp push_enabled_for?(%Notification{type: :message}, %UserSettings{
+         message_push_enabled: false
+       }),
+       do: false
+
+  defp push_enabled_for?(%Notification{type: type}, %UserSettings{
+         system_push_enabled: false
+       })
+       when type in [:system, :moderation, :call, :contact, :group],
+       do: false
+
+  defp push_enabled_for?(_notif, _us), do: true
 
   # `mentions_only` blocks message-type notifications that are not @-mentions
   # for the recipient. The flag is read with conversation-level overriding

--- a/test/whispr_notifications/delivery/web_push_client_test.exs
+++ b/test/whispr_notifications/delivery/web_push_client_test.exs
@@ -77,11 +77,11 @@ defmodule WhisprNotifications.Delivery.WebPushClientTest do
       :ok
     end
 
-    test "retourne {:error, :endpoint_expired} quand WebPushElixir renvoie {:error, :expired}" do
-      # on teste le mappage de retour — on ne peut pas mocker WebPushElixir directement
-      # sans un mock process, donc on valide que le code compile et que la signature est correcte
-      # via le comportement déclaré
-      assert function_exported?(WebPushClient, :send, 2)
+    test "send/2 retourne {:error, :not_configured} pour endpoint vide même avec VAPID configuré" do
+      # WebPushElixir ne peut pas être mocké sans process dédié ; on vérifie le guard
+      # sur le token vide qui court-circuite avant tout appel réseau
+      device = Map.put(@valid_device, :token, "")
+      assert {:error, :not_configured} = WebPushClient.send(device, @valid_payload)
     end
 
     test "WebPushClient implémente son propre behaviour" do
@@ -93,14 +93,16 @@ defmodule WhisprNotifications.Delivery.WebPushClientTest do
   end
 
   describe "callback behaviour" do
-    test "le module exporte send/2" do
-      assert function_exported?(WebPushClient, :send, 2)
-    end
-
     test "le module déclare le @callback send/2" do
       # vérifie que le module est un behaviour (callbacks définis)
       callbacks = WebPushClient.behaviour_info(:callbacks)
       assert {:send, 2} in callbacks
+    end
+
+    test "send/2 est appelable — retourne :error tuple avec VAPID absent" do
+      set_vapid_unconfigured()
+      result = WebPushClient.send(@valid_device, @valid_payload)
+      assert {:error, _} = result
     end
   end
 end

--- a/test/whispr_notifications/preferences/manager_test.exs
+++ b/test/whispr_notifications/preferences/manager_test.exs
@@ -250,5 +250,51 @@ defmodule WhisprNotifications.Preferences.ManagerTest do
 
       assert Manager.allowed_for_notification?(notif, ~U[2026-01-01 10:00:00Z])
     end
+
+    test "returns false for :message notif when message_push_enabled is false" do
+      uid = unique_id("pref-mgr-push-off")
+      {:ok, _} = Manager.update_user_settings(uid, %{"message_push_enabled" => false})
+
+      notif = NotificationFixtures.build_notification(%{user_id: uid, type: :message})
+
+      refute Manager.allowed_for_notification?(notif, ~U[2026-01-01 10:00:00Z])
+    end
+
+    test "returns true for :message notif when message_push_enabled is true (default)" do
+      uid = unique_id("pref-mgr-push-on")
+
+      notif = NotificationFixtures.build_notification(%{user_id: uid, type: :message})
+
+      assert Manager.allowed_for_notification?(notif, ~U[2026-01-01 10:00:00Z])
+    end
+
+    test "returns false for :system notif when system_push_enabled is false" do
+      uid = unique_id("pref-mgr-sys-off")
+      {:ok, _} = Manager.update_user_settings(uid, %{"system_push_enabled" => false})
+
+      notif = NotificationFixtures.build_notification(%{user_id: uid, type: :system})
+
+      refute Manager.allowed_for_notification?(notif, ~U[2026-01-01 10:00:00Z])
+    end
+
+    test "message_push_enabled=true still sends when mentions_only requires a mention" do
+      # push_enabled_ok et mention_ok sont deux conditions independantes
+      uid = unique_id("pref-mgr-push-mention")
+
+      {:ok, _} =
+        Manager.update_user_settings(uid, %{
+          "message_push_enabled" => true,
+          "mentions_only" => true
+        })
+
+      notif =
+        NotificationFixtures.build_notification(%{
+          user_id: uid,
+          type: :message,
+          metadata: %{"mentioned" => false}
+        })
+
+      refute Manager.allowed_for_notification?(notif, ~U[2026-01-01 10:00:00Z])
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Déplace `config :web_push_elixir` de `config.exs` vers `runtime.exs` : les clés VAPID étaient figées à `""` au build Docker, causant `{:error, :not_configured}` permanent même avec les secrets Kubernetes correctement patchés
- Ajoute la vérification de `message_push_enabled` / `system_push_enabled` dans `allowed_for_notification?` : le toggle Settings n'avait aucun effet sur l'envoi des push

## Test plan
- [ ] `mix compile --warnings-as-errors` clean
- [ ] `mix format --check-formatted` clean
- [ ] Après rollout : `Application.get_env(:web_push_elixir, :vapid_public_key)` renvoie la clé (non vide) via rpc
- [ ] Enregistrer un device web_push depuis Safari iOS sur whispr-preprod.roadmvn.com, envoyer un message -> notif reçue avec `sender_name` dans le titre
- [ ] Désactiver notifications dans Settings -> plus de push reçus