### PR TITLE
feat(mute): expose GET /api/conversations/mutes pour sync boot

### DIFF
--- a/lib/whispr_notifications/preferences/manager.ex
+++ b/lib/whispr_notifications/preferences/manager.ex
@@ -4,6 +4,8 @@ defmodule WhisprNotifications.Preferences.Manager do
   Persiste via Ecto sur PostgreSQL.
   """
 
+  import Ecto.Query, warn: false
+
   alias WhisprNotifications.Notifications.Notification
   alias WhisprNotifications.Preferences.{ConversationSettings, UserSettings}
   alias WhisprNotifications.Repo
@@ -86,6 +88,20 @@ defmodule WhisprNotifications.Preferences.Manager do
     existing
     |> ConversationSettings.changeset(attrs)
     |> Repo.insert_or_update()
+  end
+
+  @doc """
+  Liste les conversations actuellement mutées pour un utilisateur.
+  Filtre les mutes expirés (mute_until passé).
+  """
+  @spec list_muted_conversations(String.t(), DateTime.t()) :: [ConversationSettings.t()]
+  def list_muted_conversations(user_id, now \\ DateTime.utc_now()) when is_binary(user_id) do
+    from(s in ConversationSettings,
+      where:
+        s.user_id == ^user_id and s.muted == true and
+          (is_nil(s.mute_until) or s.mute_until > ^now)
+    )
+    |> Repo.all()
   end
 
   @spec allowed_for_notification?(Notification.t(), DateTime.t()) :: boolean()

--- a/lib/whispr_notifications_web/controllers/mute_controller.ex
+++ b/lib/whispr_notifications_web/controllers/mute_controller.ex
@@ -3,6 +3,31 @@ defmodule WhisprNotificationsWeb.MuteController do
 
   alias WhisprNotifications.Preferences.Manager
 
+  # GET /api/conversations/mutes
+  # Retourne la liste des conversations mutées par l'utilisateur courant (jwt_sub).
+  # Permet au frontend de synchroniser l'etat is_muted au boot, vu que messaging-service
+  # n'est pas la source de verite pour le mute (cf bug desync front<->back).
+  def index(conn, _params) do
+    case conn.assigns[:jwt_sub] do
+      sub when is_binary(sub) ->
+        mutes =
+          sub
+          |> Manager.list_muted_conversations()
+          |> Enum.map(fn s ->
+            %{
+              conversation_id: s.conversation_id,
+              muted: s.muted,
+              mute_until: s.mute_until
+            }
+          end)
+
+        json(conn, %{mutes: mutes})
+
+      _ ->
+        forbidden(conn)
+    end
+  end
+
   # POST /api/conversations/:conversation_id/mute
   # user_id: optionnel dans le body. S'il est fourni, il doit être égal au
   # `sub` du JWT, sinon 403. S'il est absent, le `sub` du JWT est utilisé.

--- a/lib/whispr_notifications_web/router.ex
+++ b/lib/whispr_notifications_web/router.ex
@@ -24,6 +24,7 @@ defmodule WhisprNotificationsWeb.Router do
 
     resources("/settings", SettingsController, only: [:show, :update])
 
+    get("/conversations/mutes", MuteController, :index)
     post("/conversations/:conversation_id/mute", MuteController, :mute)
     delete("/conversations/:conversation_id/mute", MuteController, :unmute)
 
@@ -54,6 +55,7 @@ defmodule WhisprNotificationsWeb.Router do
 
     resources("/settings", SettingsController, only: [:show, :update])
 
+    get("/conversations/mutes", MuteController, :index)
     post("/conversations/:conversation_id/mute", MuteController, :mute)
     delete("/conversations/:conversation_id/mute", MuteController, :unmute)
 

--- a/test/whispr_notifications_web/controllers/mute_controller_test.exs
+++ b/test/whispr_notifications_web/controllers/mute_controller_test.exs
@@ -154,6 +154,115 @@ defmodule WhisprNotificationsWeb.MuteControllerTest do
     end
   end
 
+  describe "index/2 — list muted conversations" do
+    test "returns empty list when user has no muted conversations" do
+      user_id = unique_id("u")
+
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> assign(:jwt_sub, user_id)
+        |> MuteController.index(%{})
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body) == %{"mutes" => []}
+    end
+
+    test "returns muted conversations after POST mute" do
+      user_id = unique_id("u")
+      conv_id = unique_id("conv")
+
+      :post
+      |> build_conn(conv_id, user_id)
+      |> MuteController.mute(%{"conversation_id" => conv_id, "user_id" => user_id})
+
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> assign(:jwt_sub, user_id)
+        |> MuteController.index(%{})
+
+      assert conn.status == 200
+      assert %{"mutes" => [entry]} = Jason.decode!(conn.resp_body)
+      assert entry["conversation_id"] == conv_id
+      assert entry["muted"] == true
+      assert entry["mute_until"] == nil
+    end
+
+    test "filters out expired mute_until entries" do
+      user_id = unique_id("u")
+      past_conv = unique_id("conv-past")
+      future_conv = unique_id("conv-future")
+
+      past_iso =
+        DateTime.utc_now()
+        |> DateTime.add(-3600, :second)
+        |> DateTime.to_iso8601()
+
+      future_iso =
+        DateTime.utc_now()
+        |> DateTime.add(3600, :second)
+        |> DateTime.to_iso8601()
+
+      :post
+      |> build_conn(past_conv, user_id)
+      |> MuteController.mute(%{
+        "conversation_id" => past_conv,
+        "user_id" => user_id,
+        "mute_until" => past_iso
+      })
+
+      :post
+      |> build_conn(future_conv, user_id)
+      |> MuteController.mute(%{
+        "conversation_id" => future_conv,
+        "user_id" => user_id,
+        "mute_until" => future_iso
+      })
+
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> assign(:jwt_sub, user_id)
+        |> MuteController.index(%{})
+
+      assert conn.status == 200
+      assert %{"mutes" => mutes} = Jason.decode!(conn.resp_body)
+      conv_ids = Enum.map(mutes, & &1["conversation_id"])
+      assert future_conv in conv_ids
+      refute past_conv in conv_ids
+    end
+
+    test "returns 403 when jwt_sub is missing" do
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> MuteController.index(%{})
+
+      assert conn.status == 403
+      assert Jason.decode!(conn.resp_body) == %{"error" => "forbidden"}
+    end
+
+    test "does not leak mutes from other users" do
+      user_a = unique_id("u-a")
+      user_b = unique_id("u-b")
+      conv_a = unique_id("conv-a")
+
+      :post
+      |> build_conn(conv_a, user_a)
+      |> MuteController.mute(%{"conversation_id" => conv_a, "user_id" => user_a})
+
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> assign(:jwt_sub, user_b)
+        |> MuteController.index(%{})
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body) == %{"mutes" => []}
+    end
+  end
+
   describe "unmute/2 — authorization" do
     test "returns 204 when body user_id matches jwt_sub" do
       conv_id = unique_id("conv")


### PR DESCRIPTION
## Contexte

Bug de desync entre `notification-service` (source de verite reelle du mute) et `messaging-service` (lu par le frontend pour l'etat `is_muted`).

Aujourd'hui :
- Mobile fait `POST /notification/api/conversations/:id/mute` -> ecrit dans `conversation_settings` (notif-service).
- Mobile lit `is_muted` depuis le payload de `messaging-service` qui n'a jamais ete update.
- Au prochain `fetchConversations`, l'optimistic update est ecrase et l'icone "mute" disparait.

## Fix

Expose un endpoint de lecture pour que le frontend puisse synchroniser l'etat mute au boot, sans dual-write cross-service.

- `GET /api/conversations/mutes` (et son alias `/notification/api/conversations/mutes`) retourne la liste des conversations mutees pour le `jwt_sub` courant.
- Filtre les `mute_until` expires cote DB.
- Authentification via le meme plug que les autres routes (`:jwt_authenticated`).
- Payload : `{"mutes": [{conversation_id, muted, mute_until}]}`.

## Tests

5 nouveaux tests dans `mute_controller_test.exs` :
- liste vide quand l'utilisateur n'a rien mute
- liste peuplee apres POST mute
- filtrage du mute_until expire
- 403 si jwt_sub manquant
- isolation par utilisateur (pas de leak entre users)

609 tests verts en local via `docker compose -f docker/test/compose.yml`.

## Coordination

Doit shipper avant la PR mobile-app (sans ce GET le frontend ne peut pas sync l'etat au boot).