### PR TITLE
fix(moderation): accepter le payload camelCase publie par user-service

### DIFF
--- a/lib/whispr_notifications/events/moderation_events.ex
+++ b/lib/whispr_notifications/events/moderation_events.ex
@@ -41,37 +41,43 @@ defmodule WhisprNotifications.Events.ModerationEvents do
   @doc "Notify a user when a sanction is applied to them."
   @spec handle_sanction_applied(map()) :: {:ok, Notification.t()} | {:error, term()}
   def handle_sanction_applied(payload) do
-    title =
-      case payload["sanction_type"] do
-        "mute" -> "You have been muted"
-        "kick" -> "You have been removed from a conversation"
-        "warning" -> "You have received a warning"
-        "temp_ban" -> "Your account has been temporarily suspended"
-        "perm_ban" -> "Your account has been suspended"
-        _ -> "Moderation action taken"
-      end
-
-    body = "Reason: #{payload["reason"] || "Violation of community guidelines"}"
-
-    body =
-      if payload["expires_at"],
-        do: body <> ". Expires: #{payload["expires_at"]}",
-        else: body
+    # user-service publie en camelCase (userId, sanctionType...) tandis que
+    # messaging-service publie en snake_case (user_id, sanction_type...).
+    # On accepte les deux formats pour ne pas perdre la notif cote user-service.
+    user_id = payload["user_id"] || payload["userId"]
+    sanction_type = payload["sanction_type"] || payload["type"]
+    reason = payload["reason"]
+    expires_at = payload["expires_at"] || payload["expiresAt"]
+    sanction_id = payload["sanction_id"] || payload["sanctionId"]
 
     Notifications.create(%{
-      user_id: payload["user_id"],
+      user_id: user_id,
       type: :system,
-      title: title,
-      body: body,
+      title: sanction_title(sanction_type),
+      body: sanction_body(reason, expires_at),
       context: %{
         "event" => "sanction_applied",
-        "sanction_type" => payload["sanction_type"],
-        "reason" => payload["reason"],
-        "expires_at" => payload["expires_at"]
+        "sanction_type" => sanction_type,
+        "sanction_id" => sanction_id,
+        "reason" => reason,
+        "expires_at" => expires_at
       }
     })
-    |> log_result("Sanction notification", user_id: payload["user_id"])
+    |> log_result("Sanction notification", user_id: user_id)
   end
+
+  defp sanction_title("mute"), do: "You have been muted"
+  defp sanction_title("kick"), do: "You have been removed from a conversation"
+  defp sanction_title("warning"), do: "You have received a warning"
+  defp sanction_title("temp_ban"), do: "Your account has been temporarily suspended"
+  defp sanction_title("perm_ban"), do: "Your account has been suspended"
+  defp sanction_title(_), do: "Moderation action taken"
+
+  defp sanction_body(reason, nil),
+    do: "Reason: #{reason || "Violation of community guidelines"}"
+
+  defp sanction_body(reason, expires_at),
+    do: "Reason: #{reason || "Violation of community guidelines"}. Expires: #{expires_at}"
 
   @doc "Notify a user when a sanction is lifted."
   @spec handle_sanction_lifted(map()) :: {:ok, Notification.t()} | {:error, term()}

--- a/test/whispr_notifications/events/moderation_events_test.exs
+++ b/test/whispr_notifications/events/moderation_events_test.exs
@@ -63,6 +63,26 @@ defmodule WhisprNotifications.Events.ModerationEventsTest do
       assert {:ok, notif} = ModerationEvents.handle_sanction_applied(payload)
       assert notif.title == "Moderation action taken"
     end
+
+    # user-service publie en camelCase (userId/type/expiresAt/sanctionId).
+    # Garantit qu'on lit le bon champ et qu'on ne perd pas la notif.
+    test "accepts camelCase payload from user-service" do
+      payload = %{
+        "userId" => "user-camel",
+        "type" => "warning",
+        "reason" => "Spamming",
+        "expiresAt" => "2026-06-01T12:00:00Z",
+        "sanctionId" => "sanction-cc-1"
+      }
+
+      assert {:ok, notif} = ModerationEvents.handle_sanction_applied(payload)
+      assert notif.user_id == "user-camel"
+      assert notif.title == "You have received a warning"
+      assert notif.body =~ "Spamming"
+      assert notif.body =~ "Expires:"
+      assert notif.context["sanction_type"] == "warning"
+      assert notif.context["sanction_id"] == "sanction-cc-1"
+    end
   end
 
   describe "handle_sanction_lifted/1" do


### PR DESCRIPTION
## Contexte

Le canal Redis `whispr:moderation:sanction_applied` est publie par deux services avec deux conventions de naming differentes:

- **user-service** (NestJS): `userId`, `type`, `expiresAt`, `sanctionId` (camelCase)
- **messaging-service** (Elixir): `user_id`, `sanction_type`, `expires_at`, `sanction_id` (snake_case)

Le consumer `ModerationEvents.handle_sanction_applied/1` ne lisait que les cles snake_case. Resultat: les sanctions issues du user-service creaient une notification avec `user_id: nil`, donc aucune push n'etait envoyee a l'utilisateur sanctionne.

## Fix

On lit les deux formats avec un fallback. Le path snake_case reste prioritaire pour la retrocompatibilite, et on rabat sur camelCase si snake_case absent.

Refactor mineur en parallele: extrait `sanction_title/1` et `sanction_body/2` pour passer Credo (complexite reduite de 13 a 9).

## Test plan

- [x] `mix test` vert sur `moderation_events_test.exs` + `moderation_events_extra_test.exs` + `moderation_subscriber_test.exs` (30 tests, 0 failures)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict lib/whispr_notifications/events/moderation_events.ex` clean
- [x] Nouveau test "accepts camelCase payload from user-service" couvre le format user-service