### PR TITLE
sync(main): merge deploy/preprod du 2026-05-27 (soir)

### DIFF
--- a/lib/whispr_notifications/events/moderation_events.ex
+++ b/lib/whispr_notifications/events/moderation_events.ex
@@ -41,37 +41,43 @@ defmodule WhisprNotifications.Events.ModerationEvents do
   @doc "Notify a user when a sanction is applied to them."
   @spec handle_sanction_applied(map()) :: {:ok, Notification.t()} | {:error, term()}
   def handle_sanction_applied(payload) do
-    title =
-      case payload["sanction_type"] do
-        "mute" -> "You have been muted"
-        "kick" -> "You have been removed from a conversation"
-        "warning" -> "You have received a warning"
-        "temp_ban" -> "Your account has been temporarily suspended"
-        "perm_ban" -> "Your account has been suspended"
-        _ -> "Moderation action taken"
-      end
-
-    body = "Reason: #{payload["reason"] || "Violation of community guidelines"}"
-
-    body =
-      if payload["expires_at"],
-        do: body <> ". Expires: #{payload["expires_at"]}",
-        else: body
+    # user-service publie en camelCase (userId, sanctionType...) tandis que
+    # messaging-service publie en snake_case (user_id, sanction_type...).
+    # On accepte les deux formats pour ne pas perdre la notif cote user-service.
+    user_id = payload["user_id"] || payload["userId"]
+    sanction_type = payload["sanction_type"] || payload["type"]
+    reason = payload["reason"]
+    expires_at = payload["expires_at"] || payload["expiresAt"]
+    sanction_id = payload["sanction_id"] || payload["sanctionId"]
 
     Notifications.create(%{
-      user_id: payload["user_id"],
+      user_id: user_id,
       type: :system,
-      title: title,
-      body: body,
+      title: sanction_title(sanction_type),
+      body: sanction_body(reason, expires_at),
       context: %{
         "event" => "sanction_applied",
-        "sanction_type" => payload["sanction_type"],
-        "reason" => payload["reason"],
-        "expires_at" => payload["expires_at"]
+        "sanction_type" => sanction_type,
+        "sanction_id" => sanction_id,
+        "reason" => reason,
+        "expires_at" => expires_at
       }
     })
-    |> log_result("Sanction notification", user_id: payload["user_id"])
+    |> log_result("Sanction notification", user_id: user_id)
   end
+
+  defp sanction_title("mute"), do: "You have been muted"
+  defp sanction_title("kick"), do: "You have been removed from a conversation"
+  defp sanction_title("warning"), do: "You have received a warning"
+  defp sanction_title("temp_ban"), do: "Your account has been temporarily suspended"
+  defp sanction_title("perm_ban"), do: "Your account has been suspended"
+  defp sanction_title(_), do: "Moderation action taken"
+
+  defp sanction_body(reason, nil),
+    do: "Reason: #{reason || "Violation of community guidelines"}"
+
+  defp sanction_body(reason, expires_at),
+    do: "Reason: #{reason || "Violation of community guidelines"}. Expires: #{expires_at}"
 
   @doc "Notify a user when a sanction is lifted."
   @spec handle_sanction_lifted(map()) :: {:ok, Notification.t()} | {:error, term()}

--- a/lib/whispr_notifications/preferences/manager.ex
+++ b/lib/whispr_notifications/preferences/manager.ex
@@ -4,6 +4,8 @@ defmodule WhisprNotifications.Preferences.Manager do
   Persiste via Ecto sur PostgreSQL.
   """
 
+  import Ecto.Query, warn: false
+
   alias WhisprNotifications.Notifications.Notification
   alias WhisprNotifications.Preferences.{ConversationSettings, UserSettings}
   alias WhisprNotifications.Repo
@@ -86,6 +88,20 @@ defmodule WhisprNotifications.Preferences.Manager do
     existing
     |> ConversationSettings.changeset(attrs)
     |> Repo.insert_or_update()
+  end
+
+  @doc """
+  Liste les conversations actuellement mutées pour un utilisateur.
+  Filtre les mutes expirés (mute_until passé).
+  """
+  @spec list_muted_conversations(String.t(), DateTime.t()) :: [ConversationSettings.t()]
+  def list_muted_conversations(user_id, now \\ DateTime.utc_now()) when is_binary(user_id) do
+    from(s in ConversationSettings,
+      where:
+        s.user_id == ^user_id and s.muted == true and
+          (is_nil(s.mute_until) or s.mute_until > ^now)
+    )
+    |> Repo.all()
   end
 
   @spec allowed_for_notification?(Notification.t(), DateTime.t()) :: boolean()

--- a/lib/whispr_notifications_web/controllers/mute_controller.ex
+++ b/lib/whispr_notifications_web/controllers/mute_controller.ex
@@ -3,6 +3,31 @@ defmodule WhisprNotificationsWeb.MuteController do
 
   alias WhisprNotifications.Preferences.Manager
 
+  # GET /api/conversations/mutes
+  # Retourne la liste des conversations mutées par l'utilisateur courant (jwt_sub).
+  # Permet au frontend de synchroniser l'etat is_muted au boot, vu que messaging-service
+  # n'est pas la source de verite pour le mute (cf bug desync front<->back).
+  def index(conn, _params) do
+    case conn.assigns[:jwt_sub] do
+      sub when is_binary(sub) ->
+        mutes =
+          sub
+          |> Manager.list_muted_conversations()
+          |> Enum.map(fn s ->
+            %{
+              conversation_id: s.conversation_id,
+              muted: s.muted,
+              mute_until: s.mute_until
+            }
+          end)
+
+        json(conn, %{mutes: mutes})
+
+      _ ->
+        forbidden(conn)
+    end
+  end
+
   # POST /api/conversations/:conversation_id/mute
   # user_id: optionnel dans le body. S'il est fourni, il doit être égal au
   # `sub` du JWT, sinon 403. S'il est absent, le `sub` du JWT est utilisé.

--- a/lib/whispr_notifications_web/router.ex
+++ b/lib/whispr_notifications_web/router.ex
@@ -24,6 +24,7 @@ defmodule WhisprNotificationsWeb.Router do
 
     resources("/settings", SettingsController, only: [:show, :update])
 
+    get("/conversations/mutes", MuteController, :index)
     post("/conversations/:conversation_id/mute", MuteController, :mute)
     delete("/conversations/:conversation_id/mute", MuteController, :unmute)
 
@@ -54,6 +55,7 @@ defmodule WhisprNotificationsWeb.Router do
 
     resources("/settings", SettingsController, only: [:show, :update])
 
+    get("/conversations/mutes", MuteController, :index)
     post("/conversations/:conversation_id/mute", MuteController, :mute)
     delete("/conversations/:conversation_id/mute", MuteController, :unmute)
 

--- a/test/whispr_notifications/events/moderation_events_test.exs
+++ b/test/whispr_notifications/events/moderation_events_test.exs
@@ -63,6 +63,26 @@ defmodule WhisprNotifications.Events.ModerationEventsTest do
       assert {:ok, notif} = ModerationEvents.handle_sanction_applied(payload)
       assert notif.title == "Moderation action taken"
     end
+
+    # user-service publie en camelCase (userId/type/expiresAt/sanctionId).
+    # Garantit qu'on lit le bon champ et qu'on ne perd pas la notif.
+    test "accepts camelCase payload from user-service" do
+      payload = %{
+        "userId" => "user-camel",
+        "type" => "warning",
+        "reason" => "Spamming",
+        "expiresAt" => "2026-06-01T12:00:00Z",
+        "sanctionId" => "sanction-cc-1"
+      }
+
+      assert {:ok, notif} = ModerationEvents.handle_sanction_applied(payload)
+      assert notif.user_id == "user-camel"
+      assert notif.title == "You have received a warning"
+      assert notif.body =~ "Spamming"
+      assert notif.body =~ "Expires:"
+      assert notif.context["sanction_type"] == "warning"
+      assert notif.context["sanction_id"] == "sanction-cc-1"
+    end
   end
 
   describe "handle_sanction_lifted/1" do

--- a/test/whispr_notifications_web/controllers/mute_controller_test.exs
+++ b/test/whispr_notifications_web/controllers/mute_controller_test.exs
@@ -154,6 +154,115 @@ defmodule WhisprNotificationsWeb.MuteControllerTest do
     end
   end
 
+  describe "index/2 — list muted conversations" do
+    test "returns empty list when user has no muted conversations" do
+      user_id = unique_id("u")
+
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> assign(:jwt_sub, user_id)
+        |> MuteController.index(%{})
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body) == %{"mutes" => []}
+    end
+
+    test "returns muted conversations after POST mute" do
+      user_id = unique_id("u")
+      conv_id = unique_id("conv")
+
+      :post
+      |> build_conn(conv_id, user_id)
+      |> MuteController.mute(%{"conversation_id" => conv_id, "user_id" => user_id})
+
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> assign(:jwt_sub, user_id)
+        |> MuteController.index(%{})
+
+      assert conn.status == 200
+      assert %{"mutes" => [entry]} = Jason.decode!(conn.resp_body)
+      assert entry["conversation_id"] == conv_id
+      assert entry["muted"] == true
+      assert entry["mute_until"] == nil
+    end
+
+    test "filters out expired mute_until entries" do
+      user_id = unique_id("u")
+      past_conv = unique_id("conv-past")
+      future_conv = unique_id("conv-future")
+
+      past_iso =
+        DateTime.utc_now()
+        |> DateTime.add(-3600, :second)
+        |> DateTime.to_iso8601()
+
+      future_iso =
+        DateTime.utc_now()
+        |> DateTime.add(3600, :second)
+        |> DateTime.to_iso8601()
+
+      :post
+      |> build_conn(past_conv, user_id)
+      |> MuteController.mute(%{
+        "conversation_id" => past_conv,
+        "user_id" => user_id,
+        "mute_until" => past_iso
+      })
+
+      :post
+      |> build_conn(future_conv, user_id)
+      |> MuteController.mute(%{
+        "conversation_id" => future_conv,
+        "user_id" => user_id,
+        "mute_until" => future_iso
+      })
+
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> assign(:jwt_sub, user_id)
+        |> MuteController.index(%{})
+
+      assert conn.status == 200
+      assert %{"mutes" => mutes} = Jason.decode!(conn.resp_body)
+      conv_ids = Enum.map(mutes, & &1["conversation_id"])
+      assert future_conv in conv_ids
+      refute past_conv in conv_ids
+    end
+
+    test "returns 403 when jwt_sub is missing" do
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> MuteController.index(%{})
+
+      assert conn.status == 403
+      assert Jason.decode!(conn.resp_body) == %{"error" => "forbidden"}
+    end
+
+    test "does not leak mutes from other users" do
+      user_a = unique_id("u-a")
+      user_b = unique_id("u-b")
+      conv_a = unique_id("conv-a")
+
+      :post
+      |> build_conn(conv_a, user_a)
+      |> MuteController.mute(%{"conversation_id" => conv_a, "user_id" => user_a})
+
+      conn =
+        :get
+        |> conn("/api/conversations/mutes")
+        |> assign(:jwt_sub, user_b)
+        |> MuteController.index(%{})
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body) == %{"mutes" => []}
+    end
+  end
+
   describe "unmute/2 — authorization" do
     test "returns 204 when body user_id matches jwt_sub" do
       conv_id = unique_id("conv")


### PR DESCRIPTION
## Sync deploy/preprod -> main

Synchronisation des commits livres sur preprod le 2026-05-27 (soir).

### Contenu
- PR #77 : feat(mute) - expose GET /api/conversations/mutes pour synchroniser le statut au boot
- PR #78 : fix(moderation) - accepter le payload camelCase publie par user-service (sanctions)

### Commits
- 16ece2d Merge PR #78 (sanction payload camelCase)
- 5177cd4 fix(moderation): accepter le payload camelCase publie par user-service
- 6340ad2 Merge PR #77 (GET /mutes endpoint)
- 1d0805d feat(mute): expose GET /api/conversations/mutes

### Verification
- CI verte sur deploy/preprod
- Pas de changement de schema BDD
- Pas de breaking change route existante